### PR TITLE
Replace `quarkus-bootstrap-maven-plugin` with `quarkus-extension-maven-plugin`

### DIFF
--- a/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
@@ -1057,6 +1057,10 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: io.quarkus.arc.Priority
       newFullyQualifiedTypeName: jakarta.annotation.Priority
+  - org.openrewrite.text.FindAndReplace:
+      find: quarkus-bootstrap-maven-plugin
+      replace: quarkus-extension-maven-plugin
+      fileMatcher: '**/pom.xml'
 
 #####
 # Update the Quarkiverse extensions


### PR DESCRIPTION
- Required for https://github.com/quarkusio/quarkus/pull/32186