### PR TITLE
Move the core upgrade recipe to a separate JAR

### DIFF
--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -15,6 +15,25 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-core-update-recipe-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/core.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>true</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
                 <configuration>

--- a/recipes/src/main/assembly/core.xml
+++ b/recipes/src/main/assembly/core.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 https://maven.apache.org/xsd/assembly-2.1.1.xsd">
+  <id>core</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>src/main/resources/quarkus-updates/core</directory>
+      <includes>
+        <include>**/*.yaml</include>
+        <include>**/*.yml</include>
+      </includes>
+      <outputDirectory>META-INF/rewrite</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
The `maven-jar-plugin` can only include/exclude resources, but not move them to a different directory in the output folder; the assembly plugin can.

@ia3andy Keep in mind that a similar assembly will have to be provided for every directory under `src/main/resources/quarkus-updates` if it releases in a separate JAR file.