### PR TITLE
Trying to add custom java rule

### DIFF
--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -12,8 +12,106 @@
     <artifactId>quarkus-update-recipes</artifactId>
     <name>Quarkus Updates - Recipes</name>
 
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.openrewrite.recipe</groupId>
+                <artifactId>rewrite-recipe-bom</artifactId>
+                <version>1.19.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- rewrite-java dependencies only necessary for Java Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java</artifactId>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>antlr-runtime</artifactId>
+                    <groupId>org.antlr</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>javax.json</artifactId>
+                    <groupId>org.glassfish</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- You only need the version that corresponds to your current
+        Java version. It is fine to add all of them, though, as
+        they can coexist on a classpath. -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-8</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-11</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-17</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- rewrite-maven dependency only necessary for Maven Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-maven</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- rewrite-yaml dependency only necessary for Yaml Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-yaml</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- rewrite-properties dependency only necessary for Properties Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-properties</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- rewrite-xml dependency only necessary for XML Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-xml</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- lombok is optional, but recommended for authoring recipes -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.28</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- For authoring tests for any kind of Recipe -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M8</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -12,6 +12,9 @@
     <artifactId>quarkus-update-recipes</artifactId>
     <name>Quarkus Updates - Recipes</name>
 
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -30,7 +33,7 @@
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <artifactId>antlr-runtime</artifactId>
@@ -49,45 +52,45 @@
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java-8</artifactId>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java-11</artifactId>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java-17</artifactId>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <!-- rewrite-maven dependency only necessary for Maven Recipe development -->
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-maven</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <!-- rewrite-yaml dependency only necessary for Yaml Recipe development -->
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-yaml</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <!-- rewrite-properties dependency only necessary for Properties Recipe development -->
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-properties</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <!-- rewrite-xml dependency only necessary for XML Recipe development -->
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-xml</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
 
         <!-- lombok is optional, but recommended for authoring recipes -->
@@ -109,8 +112,11 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M8</version>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/recipes/src/main/java/org/apache/camel/quarkus/update/SayHelloRecipe.java
+++ b/recipes/src/main/java/org/apache/camel/quarkus/update/SayHelloRecipe.java
@@ -1,0 +1,76 @@
+package org.apache.camel.quarkus.update;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.lang.NonNull;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+
+// Making your recipe immutable helps make them idempotent and eliminates categories of possible bugs.
+// Configuring your recipe in this way also guarantees that basic validation of parameters will be done for you by rewrite.
+// Also note: All recipes must be serializable. This is verified by RewriteTest.rewriteRun() in your tests.
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class SayHelloRecipe extends Recipe {
+    @Option(displayName = "Fully Qualified Class Name",
+            description = "A fully qualified class name indicating which class to add a hello() method to.",
+            example = "com.yourorg.FooBar")
+    @NonNull
+    String fullyQualifiedClassName = "com.yourorg.FooBar";
+
+    @Override
+    public String getDisplayName() {
+        return "Say Hello";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds a \"hello\" method to the specified class.";
+    }
+
+    @Override
+    protected JavaIsoVisitor<ExecutionContext> getVisitor() {
+        // getVisitor() should always return a new instance of the visitor to avoid any state leaking between cycles
+        return new SayHelloVisitor();
+    }
+
+    public class SayHelloVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private final JavaTemplate helloTemplate =
+                JavaTemplate.builder(this::getCursor, "public String hello() { return \"Hello from #{}!\"; }")
+                        .build();
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+            // Don't make changes to classes that don't match the fully qualified name
+            if (classDecl.getType() == null || !classDecl.getType().getFullyQualifiedName().equals(fullyQualifiedClassName)) {
+                return classDecl;
+            }
+
+
+            // Check if the class already has a method named "hello".
+            boolean helloMethodExists = classDecl.getBody().getStatements().stream()
+                    .filter(statement -> statement instanceof J.MethodDeclaration)
+                    .map(J.MethodDeclaration.class::cast)
+                    .anyMatch(methodDeclaration -> methodDeclaration.getName().getSimpleName().equals("hello"));
+
+            // If the class already has a `hello()` method, don't make any changes to it.
+            if (helloMethodExists) {
+                return classDecl;
+            }
+
+            // Interpolate the fullyQualifiedClassName into the template and use the resulting LST to update the class body
+            classDecl = classDecl.withBody(
+                    classDecl.getBody().withTemplate(
+                            helloTemplate,
+                            classDecl.getBody().getCoordinates().lastStatement(),
+                            fullyQualifiedClassName
+                    ));
+
+            return classDecl;
+        }
+    }
+}

--- a/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
@@ -30,7 +30,7 @@ name: custom
 displayName: customNme
 description: customDesc
 recipeList:
-  - org.apache.camel.quarkus.poc.SayHelloRecipe
+  - org.apache.camel.quarkus.update.SayHelloRecipe
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse

--- a/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
@@ -26,6 +26,13 @@
 #####
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: custom
+displayName: customNme
+description: customDesc
+recipeList:
+  - org.apache.camel.quarkus.poc.SayHelloRecipe
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse
 recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:


### PR DESCRIPTION
This is an experiment with addition of java custom rule among the upgrade process.

Current PR is buildable but when upgrade is executed, I'm getting:

```
[INFO] [INFO] Using active recipe(s) [io.quarkus.openrewrite.Quarkus]
[INFO] [INFO] Using active styles(s) []
[INFO] [INFO] Validating active recipes...
[INFO] [ERROR] Recipe validation error in custom.recipeList[0] (in file:/tmp/quarkus-project-recipe-10422657056364188551.yaml): recipe 'org.apache.camel.quarkus.poc.SayHelloRecipe' does not exist.
[INFO] [ERROR] Recipe validation error in custom.recipeList[0] (in file:/tmp/quarkus-project-recipe-10422657056364188551.yaml): recipe 'org.apache.camel.quarkus.poc.SayHelloRecipe' does not exist.
[INFO] [ERROR] Recipe validation error in custom.recipeList[0] (in file:/tmp/quarkus-project-recipe-10422657056364188551.yaml): recipe 'org.apache.camel.quarkus.poc.SayHelloRecipe' does not exist.
```

I expect, that the `maven-rewrite` plugin which is resolved in runtime has to contain a reference to recipe. Something like this xml definition:

```
   <plugin>
            <groupId>org.openrewrite.maven</groupId>
            <artifactId>rewrite-maven-plugin</artifactId>
            <version>4.46.0</version>
            <configuration>
                <activeRecipes>
                    <recipe>org.apache.camel.quarkus.update.SayHelloRecipe</recipe>
                </activeRecipes>
            </configuration>
            <dependencies>
                <dependency>
                    <groupId>org.apache.camel.quarkus.update</groupId>
                    <artifactId>recipes</artifactId>
                    <version>1.0-SNAPSHOT</version>
                </dependency>
            </dependencies>
        </plugin>

```