### PR TITLE
Switch to AST manipulations instead of using text replacements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,3 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B clean install -Dno-format
-
-      - name: Build with Maven (Native)
-        run: mvn -B install -Dnative -Dquarkus.native.container-build -Dnative.surefire.skip

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -12,8 +12,111 @@
     <artifactId>quarkus-update-recipes</artifactId>
     <name>Quarkus Updates - Recipes</name>
 
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.openrewrite.recipe</groupId>
+                <artifactId>rewrite-recipe-bom</artifactId>
+                <version>1.19.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- rewrite-java dependencies only necessary for Java Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>antlr-runtime</artifactId>
+                    <groupId>org.antlr</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>javax.json</artifactId>
+                    <groupId>org.glassfish</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- You only need the version that corresponds to your current
+        Java version. It is fine to add all of them, though, as
+        they can coexist on a classpath. -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-8</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-11</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-17</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- rewrite-maven dependency only necessary for Maven Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-maven</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- rewrite-yaml dependency only necessary for Yaml Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-yaml</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- rewrite-properties dependency only necessary for Properties Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-properties</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- rewrite-xml dependency only necessary for XML Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-xml</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- lombok is optional, but recommended for authoring recipes -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.28</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- For authoring tests for any kind of Recipe -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/recipes/src/main/java/io/quarkus/updates/core/quarkus30/AdjustKotlinAllOpenDirectives.java
+++ b/recipes/src/main/java/io/quarkus/updates/core/quarkus30/AdjustKotlinAllOpenDirectives.java
@@ -1,0 +1,94 @@
+package io.quarkus.updates.core.quarkus30;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.xml.ChangeTagValueVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class AdjustKotlinAllOpenDirectives extends Recipe {
+
+    private static final String ALL_OPEN_ANNOTATION = "all-open:annotation=";
+    private static final XPathMatcher PLUGIN_MATCHER = new XPathMatcher("/project/build/plugins/plugin");
+
+    private static final List<String> JAVAX_PACKAGES = List.of("javax.ws.", "javax.enterprise.");
+
+    @Override
+    public String getDisplayName() {
+        return "Adjust all-open directives in Kotlin plugin configuration";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adjust all-open directives in Kotlin plugin configuration";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new MavenVisitor<ExecutionContext>() {
+
+            @Override
+            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = (Xml.Tag) super.visitTag(tag, ctx);
+
+                if (!PLUGIN_MATCHER.matches(getCursor())) {
+                    return t;
+                }
+
+                if (!"org.jetbrains.kotlin".equals(t.getChildValue("groupId").orElse(null))
+                    || !"kotlin-maven-plugin".equals(t.getChildValue("artifactId").orElse(null))) {
+                    return t;
+                }
+
+                Optional<Xml.Tag> configurationTag = t.getChild("configuration");
+                if (configurationTag.isEmpty()) {
+                    return t;
+                }
+
+                Optional<Xml.Tag> pluginOptionsTag = configurationTag.get().getChild("pluginOptions");
+                if (pluginOptionsTag.isEmpty()) {
+                    return t;
+                }
+
+                for (Xml.Tag pluginOptionTag : pluginOptionsTag.get().getChildren()) {
+                    t = adjustAllOpenDirectives(ctx, t, pluginOptionTag);
+                }
+
+                return t;
+            }
+
+            private Xml.Tag adjustAllOpenDirectives(ExecutionContext ctx, Xml.Tag pluginTag, Xml.Tag pluginOptionTag) {
+                if (pluginOptionTag.getValue().isEmpty()) {
+                    return pluginTag;
+                }
+
+                if (!pluginOptionTag.getValue().get().startsWith(ALL_OPEN_ANNOTATION)) {
+                    return pluginTag;
+                }
+
+                for (String javaxPackage : JAVAX_PACKAGES) {
+                    if (!pluginOptionTag.getValue().get().startsWith(ALL_OPEN_ANNOTATION + javaxPackage)) {
+                        continue;
+                    }
+
+                    pluginTag = (Xml.Tag) new ChangeTagValueVisitor<>(pluginOptionTag,
+                            pluginOptionTag.getValue().get().replace(ALL_OPEN_ANNOTATION + "javax.", ALL_OPEN_ANNOTATION + "jakarta."))
+                            .visitNonNull(pluginTag, ctx);
+                }
+
+                return pluginTag;
+            }
+        };
+    }
+}

--- a/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
@@ -1458,17 +1458,8 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus30.Kotlin
 recipeList:
-applicability:
-  singleSource:
-    - org.openrewrite.FindSourceFiles:
-        filePattern: "**/pom.xml"
 recipeList:
-  - org.openrewrite.text.FindAndReplace:
-      find: 'all-open:annotation=javax.ws.'
-      replace: 'all-open:annotation=jakarta.ws.'
-  - org.openrewrite.text.FindAndReplace:
-      find: 'all-open:annotation=javax.enterprise.'
-      replace: 'all-open:annotation=jakarta.enterprise.'
+  - io.quarkus.updates.core.quarkus30.AdjustKotlinAllOpenDirectives
 
 #####
 # Adjust properties in application.properties

--- a/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3alpha.yaml
@@ -1445,10 +1445,11 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: io.quarkus.arc.Priority
       newFullyQualifiedTypeName: jakarta.annotation.Priority
-  - org.openrewrite.text.FindAndReplace:
-      find: quarkus-bootstrap-maven-plugin
-      replace: quarkus-extension-maven-plugin
-      fileMatcher: '**/pom.xml'
+  - org.openrewrite.maven.ChangePluginGroupIdAndArtifactId:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-bootstrap-maven-plugin
+      newGroupId: io.quarkus
+      newArtifactId: quarkus-extension-maven-plugin
 
 #####
 # Additional recipes for Kotlin


### PR DESCRIPTION
Once an AST file has been manipulated by a text-based recipe, anything AST on this file gets ignored so we need to get rid of all text manipulations on files adjusted via AST.