### PR TITLE
Recipes for camel-quarkus

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,11 @@ jobs:
         if: startsWith(matrix.os, 'windows')
 
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
 
     <modules>
         <module>recipes</module>
+        <module>recipes-unit-tests</module>
     </modules>
 
     <distributionManagement>

--- a/recipes-unit-tests/pom.xml
+++ b/recipes-unit-tests/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -9,11 +10,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>quarkus-update-recipes</artifactId>
-    <name>Quarkus Updates - Recipes</name>
+    <artifactId>quarkus-update-recipes-unit-tests</artifactId>
+    <name>Quarkus Updates - Recipes - Unit tests</name>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <!-- Make sure all these versions are aligned and use a compatible OpenRewrite version -->
         <!--   https://central.sonatype.com/artifact/org.openrewrite.recipe/rewrite-recipe-bom/2.0.3/versions -->
@@ -22,17 +23,20 @@
         <rewrite-maven-plugin.version>4.46.0</rewrite-maven-plugin.version>
         <!--   for now, we don't know where to find compatibility information for the Gradle plugin -->
         <rewrite-gradle-plugin.version>5.40.6</rewrite-gradle-plugin.version>
-        <!-- If version from rewrite-recipe-bom is used, error occures during testing ->
-         NoSuchMethod 'com.fasterxml.jackson.core.util.TextBuffer com.fasterxml.jackson.core.io.IOContext.constructReadConstrainedTextBuffer()'
-        -->
-        <rewrite-migrate-java.version>1.16.0</rewrite-migrate-java.version>
+
         <!-- tests-->
         <junit.version>5.4.0</junit.version>
         <surefire.plugin.version>3.1.0</surefire.plugin.version>
+        <!-- Camel quarkus version used by the tests -->
+        <camel-quarkus.version>2.13.3</camel-quarkus.version>
         <!-- Http version used by the tests -->
         <http.version>4.5.14</http.version>
 
         <lombok.version>1.18.28</lombok.version>
+
+        <!-- Maven plugins versions -->
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <license-maven-plugin.version>4.2</license-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -41,6 +45,13 @@
                 <groupId>org.openrewrite.recipe</groupId>
                 <artifactId>rewrite-recipe-bom</artifactId>
                 <version>${rewrite-recipe-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.quarkus</groupId>
+                <artifactId>camel-quarkus-bom</artifactId>
+                <version>${camel-quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -82,11 +93,6 @@
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java-17</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.openrewrite.recipe</groupId>
-            <artifactId>rewrite-migrate-java</artifactId>
-            <version>${rewrite-migrate-java.version}</version>
         </dependency>
 
         <!-- rewrite-maven dependency only necessary for Maven Recipe development -->
@@ -132,6 +138,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- recipes -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-update-recipes</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- For authoring tests for any kind of Recipe -->
         <dependency>
             <groupId>org.openrewrite</groupId>
@@ -150,6 +163,52 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!--test dependencies -->
+
+        <!-- Camel quarkus testing -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-catalog</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-activemq</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-bean</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${http.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -172,28 +231,10 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
                 <configuration>
                     <propertiesEncoding>UTF-8</propertiesEncoding>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-core-update-recipe-jar</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>src/main/assembly/core.xml</descriptor>
-                            </descriptors>
-                            <appendAssemblyId>true</appendAssemblyId>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -224,16 +265,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>15</source>
+                    <target>15</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -253,7 +294,54 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
+
+    <profiles>
+
+        <profile>
+            <!-- Sanity checks and formatting are disabled when building with '-Dquickly' -->
+            <id>full</id>
+            <activation>
+                <property>
+                    <name>!quickly</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>format</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>license-format</id>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                                <phase>validate</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CameXmlDslRecipeTest.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CameXmlDslRecipeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.updates.camel30;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CameXmlDslRecipeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelQuarkusTestUtil.recipe(spec)
+                .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testDescription() {
+        rewriteRun(xml("""
+                <routes xmlns="http://camel.apache.org/schema/spring">
+                    <route id="myRoute">
+                        <description>Something that this route do</description>
+                        <from uri="kafka:cheese"/>
+                        <setBody>
+                           <constant>Hello Camel K!</constant>
+                        </setBody>
+                       <to uri="log:info"/>
+                    </route>
+                    <route id="myRoute2">
+                        <description>Something that this route2 do</description>
+                        <from uri="kafka:cheese"/>
+                        <setBody>
+                           <constant>Hello Camel K!</constant>
+                        </setBody>
+                       <to uri="log:info"/>
+                    </route>
+                </routes>
+                                                """, """
+                    <routes xmlns="http://camel.apache.org/schema/spring">
+                        <route id="myRoute" description="Something that this route do">
+                            <from uri="kafka:cheese"/>
+                            <setBody>
+                               <constant>Hello Camel K!</constant>
+                            </setBody>
+                           <to uri="log:info"/>
+                        </route>
+                        <route id="myRoute2" description="Something that this route2 do">
+                            <from uri="kafka:cheese"/>
+                            <setBody>
+                               <constant>Hello Camel K!</constant>
+                            </setBody>
+                           <to uri="log:info"/>
+                        </route>
+                    </routes>
+                """));
+    }
+}

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelAPIsPropertiesTest.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelAPIsPropertiesTest.java
@@ -1,0 +1,43 @@
+package io.quarkus.updates.camel30;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.properties.Assertions;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CamelAPIsPropertiesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelQuarkusTestUtil.recipe(spec, "org.openrewrite.java.camel.migrate.ChangePropertyValue")
+                .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testRejectedPolicyDiscardOldeste() {
+        rewriteRun(Assertions.properties("""
+                   #test
+                   camel.threadpool.rejectedPolicy=DiscardOldest
+                """,
+                """
+                            #test
+                            camel.threadpool.rejectedPolicy=Abort #DiscardOldest has been removed, consider Abort
+                        """));
+    }
+
+    @Test
+    void testRejectedPolicyDiscard() {
+        rewriteRun(Assertions.properties("""
+                   #test
+                   camel.threadpool.rejectedPolicy=Discard
+                """,
+                """
+                            #test
+                            camel.threadpool.rejectedPolicy=Abort #Discard has been removed, consider Abort
+                        """));
+    }
+
+}

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelAPIsTest.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelAPIsTest.java
@@ -1,0 +1,1010 @@
+package io.quarkus.updates.camel30;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CamelAPIsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelQuarkusTestUtil.recipe(spec)
+                .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true).classpath("camel-api",
+                        "camel-support", "camel-core-model", "camel-util", "camel-catalog", "camel-main"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testRemovedExchangePatternInOptionalOut() {
+        rewriteRun(java("""
+                    import org.apache.camel.ExchangePattern;
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+
+                            String uri = "log:c";
+
+                            from("direct:start")
+                                    .toD("log:a", true)
+                                    .to(ExchangePattern.InOptionalOut, "log:b")
+                                    .to(uri);
+                        }
+                    }
+                """, """
+                import org.apache.camel.ExchangePattern;
+                import org.apache.camel.builder.RouteBuilder;
+
+                public class MySimpleToDRoute extends RouteBuilder {
+
+                    @Override
+                    public void configure() {
+
+                        String uri = "log:c";
+
+                        from("direct:start")
+                                .toD("log:a", true)
+                                .to(ExchangePattern./* InOptionalOut has been removed */, "log:b")
+                                .to(uri);
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testRemovedFullyExchangePatternInOptionalOut() {
+        rewriteRun(java("""
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+
+                            String uri = "log:c";
+
+                            from("direct:start")
+                                    .toD("log:a", true)
+                                    .to(org.apache.camel.ExchangePattern.InOptionalOut, "log:b")
+                                    .to(uri);
+                        }
+                    }
+                """, """
+                import org.apache.camel.builder.RouteBuilder;
+
+                public class MySimpleToDRoute extends RouteBuilder {
+
+                    @Override
+                    public void configure() {
+
+                        String uri = "log:c";
+
+                        from("direct:start")
+                                .toD("log:a", true)
+                                .to(org.apache.camel.ExchangePattern./* InOptionalOut has been removed */, "log:b")
+                                .to(uri);
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testComponentNameResolver() {
+        rewriteRun(java("""
+                    import org.apache.camel.CamelContext;
+
+                    public class Test {
+
+                        CamelContext context;
+
+                        public void test() {
+                            context.getEndpointMap().containsKey("bar://order");
+                        }
+                    }
+                """,
+                """
+                        import org.apache.camel.CamelContext;
+
+                        public class Test {
+
+                            CamelContext context;
+
+                            public void test() {
+                                context./* getEndpointMap has been removed, consider getEndpointRegistry() instead */().containsKey("bar://order");
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void testFallbackConverterOnMethod() {
+        rewriteRun(java("""
+                    import org.apache.camel.FallbackConverter;
+
+                    public class Test {
+
+                        @FallbackConverter
+                        public void test() {
+                        }
+                    }
+                """, """
+                import org.apache.camel.Converter;
+
+                public class Test {
+
+                    @Converter(fallback = true)
+                    public void test() {
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testFallbackConverterOnClassDef() {
+        rewriteRun(java("""
+                    import org.apache.camel.FallbackConverter;
+
+                    @FallbackConverter
+                    public class Test {
+                    }
+                """, """
+                import org.apache.camel.Converter;
+
+                @Converter(fallback = true)
+                public class Test {
+                }
+                """));
+    }
+
+    @Test
+    void testEndpointInject() {
+        rewriteRun(java("""
+                    import org.apache.camel.component.mock.MockEndpoint;
+                    import org.apache.camel.EndpointInject;
+
+                    public class Test {
+
+                             @EndpointInject(uri = "mock:out")
+                             private MockEndpoint endpoint;
+                    }
+                """, """
+                    import org.apache.camel.component.mock.MockEndpoint;
+                    import org.apache.camel.EndpointInject;
+
+                    public class Test {
+
+                             @EndpointInject("mock:out")
+                             private MockEndpoint endpoint;
+                    }
+                """));
+    }
+
+    @Test
+    void testProduce() {
+        rewriteRun(java("""
+                    import org.apache.camel.component.mock.MockEndpoint;
+                    import org.apache.camel.Produce;
+
+                    public class Test {
+
+                             @Produce(uri = "test")
+                             private MockEndpoint endpoint() {
+                                return null;
+                             }
+                    }
+                """, """
+                    import org.apache.camel.component.mock.MockEndpoint;
+                    import org.apache.camel.Produce;
+
+                    public class Test {
+
+                             @Produce("test")
+                             private MockEndpoint endpoint() {
+                                return null;
+                             }
+                    }
+                """));
+    }
+
+    @Test
+    void testConsume() {
+        rewriteRun(java("""
+                    import org.apache.camel.component.mock.MockEndpoint;
+                    import org.apache.camel.Consume;
+
+                    public class Test {
+
+                             @Consume(uri = "test")
+                             private MockEndpoint endpoint() {
+                                return null;
+                             }
+                    }
+                """, """
+                    import org.apache.camel.component.mock.MockEndpoint;
+                    import org.apache.camel.Consume;
+
+                    public class Test {
+
+                             @Consume("test")
+                             private MockEndpoint endpoint() {
+                                return null;
+                             }
+                    }
+                """));
+    }
+
+    @Test
+    void testUriEndpoint() {
+        rewriteRun(java("""
+                import org.apache.camel.spi.UriEndpoint;
+                import org.apache.camel.support.DefaultEndpoint;
+
+                @UriEndpoint(firstVersion = "2.0.0", label = "rest", lenientProperties = true)
+                public class MicrometerEndpoint extends DefaultEndpoint {
+                }
+                """, """
+                import org.apache.camel.Category;
+                import org.apache.camel.spi.UriEndpoint;
+                import org.apache.camel.support.DefaultEndpoint;
+
+                @UriEndpoint(firstVersion = "2.0.0",category = {Category.rest}, lenientProperties = true)
+                public class MicrometerEndpoint extends DefaultEndpoint {
+                }
+                """));
+    }
+
+    @Test
+    void testUriEndpointWithUnknownValue() {
+        rewriteRun(java("""
+                import org.apache.camel.spi.UriEndpoint;
+                import org.apache.camel.support.DefaultEndpoint;
+
+                @UriEndpoint(firstVersion = "2.0.0", label = "test", lenientProperties = true)
+                public class MicrometerEndpoint extends DefaultEndpoint {
+                }
+                """,
+                """
+                        import org.apache.camel.Category;
+                        import org.apache.camel.spi.UriEndpoint;
+                        import org.apache.camel.support.DefaultEndpoint;
+
+                        @UriEndpoint(firstVersion = "2.0.0",category = {Category."test"/*unknown_value*/}, lenientProperties = true)
+                        public class MicrometerEndpoint extends DefaultEndpoint {
+                        }
+                        """));
+    }
+
+    @Test
+    void testAsyncCallback() {
+        rewriteRun(spec -> spec.expectedCyclesThatMakeChanges(2), java("""
+                import org.apache.camel.ProducerTemplate;
+                import org.apache.camel.Exchange;
+
+                public class Test {
+                    ProducerTemplate template;
+
+                    public void test() {
+                        Exchange exchange = context.getEndpoint("direct:start").createExchange();
+                        exchange.getIn().setBody("Hello");
+
+                        template.asyncCallback("direct:start", exchange, null);
+                    }
+
+                }
+                """,
+                """
+                        import org.apache.camel.ProducerTemplate;
+                        import org.apache.camel.Exchange;
+
+                        public class Test {
+                            ProducerTemplate template;
+
+                            public void test() {
+                                Exchange exchange = context.getEndpoint("direct:start").createExchange();
+                                exchange.getIn().setBody("Hello");
+
+                                /* Method 'asyncCallback()' has been replaced by 'asyncSend()' or 'asyncRequest()'.*/template.asyncCallback("direct:start", exchange, null);
+                            }
+
+                        }
+                        """));
+    }
+
+    @Test
+    void testOnCamelContextStart() {
+        rewriteRun(java("""
+                import org.apache.camel.spi.OnCamelContextStart;
+                import org.apache.camel.CamelContext;
+
+                public class Test implements OnCamelContextStart{
+                    public void onContextStart(CamelContext context) {
+                    }
+                }
+                """, """
+                import org.apache.camel.spi.OnCamelContextStarting;
+                import org.apache.camel.CamelContext;
+
+                public class Test implements OnCamelContextStarting{
+                    public void onContextStart(CamelContext context) {
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testOnCamelContextStop() {
+        rewriteRun(java("""
+                import org.apache.camel.spi.OnCamelContextStop;
+                import org.apache.camel.CamelContext;
+
+                public class Test implements OnCamelContextStop{
+                    public void onContextStop(CamelContext context) {
+                    }
+                }
+                """, """
+                import org.apache.camel.spi.OnCamelContextStopping;
+                import org.apache.camel.CamelContext;
+
+                public class Test implements OnCamelContextStopping{
+                    public void onContextStop(CamelContext context) {
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testAdapt() {
+        rewriteRun(java("""
+                    import org.apache.camel.CamelContext;
+                    import org.apache.camel.model.ModelCamelContext;
+
+                    public class Test {
+
+                        CamelContext context;
+
+                        public void test() {
+                            context.adapt(ModelCamelContext.class).getRouteDefinition("forMocking");
+                        }
+                    }
+                """, """
+                import org.apache.camel.CamelContext;
+                import org.apache.camel.model.ModelCamelContext;
+
+                public class Test {
+
+                    CamelContext context;
+
+                    public void test() {
+                        ((ModelCamelContext)context).getRouteDefinition("forMocking");
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testMoreOccurrencesAdapt() {
+        rewriteRun(spec -> spec.expectedCyclesThatMakeChanges(2), java("""
+                    import org.apache.camel.CamelContext;
+                    import org.apache.camel.model.ModelCamelContext;
+
+                    public class Test {
+
+                        CamelContext context, c1, c2, c3;
+
+                        public ModelCamelContext test() {
+                            context.adapt(ModelCamelContext.class).getRouteDefinition("forMocking");
+                            c1.adapt(ModelCamelContext.class).getRegistry();
+                            c2.adapt(ModelCamelContext.class);
+                            return c3.adapt(ModelCamelContext.class);
+                        }
+                    }
+                """, """
+                import org.apache.camel.CamelContext;
+                import org.apache.camel.model.ModelCamelContext;
+
+                public class Test {
+
+                    CamelContext context, c1, c2, c3;
+
+                    public ModelCamelContext test() {
+                        ((ModelCamelContext)context).getRouteDefinition("forMocking");
+                        ((ModelCamelContext)c1).getRegistry();
+                        /*Method 'adapt' was removed.*/c2.adapt(ModelCamelContext.class);
+                        return /*Method 'adapt' was removed.*/c3.adapt(ModelCamelContext.class);
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testAdaptStandalone() {
+        rewriteRun(spec -> spec.expectedCyclesThatMakeChanges(2), java("""
+                    import org.apache.camel.CamelContext;
+                    import org.apache.camel.model.ModelCamelContext;
+
+                    public class Test {
+
+                        CamelContext context;
+
+                        public void test() {
+
+                            context.adapt(ModelCamelContext.class);
+                        }
+                    }
+                """, """
+                import org.apache.camel.CamelContext;
+                import org.apache.camel.model.ModelCamelContext;
+
+                public class Test {
+
+                    CamelContext context;
+
+                    public void test() {
+
+                        /*Method 'adapt' was removed.*/context.adapt(ModelCamelContext.class);
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testAdapt2() {
+        rewriteRun(java("""
+                package org.apache.camel.quarkus.component.test.it;
+
+                import org.apache.camel.CamelContext;
+                import org.apache.camel.ExtendedCamelContext;
+                import org.apache.camel.impl.engine.DefaultHeadersMapFactory;
+
+                public class Test {
+
+                    CamelContext context;
+
+                    public DefaultHeadersMapFactory test() {
+                        return context.adapt(ExtendedCamelContext.class).getHeadersMapFactory();
+                    }
+                }
+                """, """
+                package org.apache.camel.quarkus.component.test.it;
+
+                import org.apache.camel.CamelContext;
+                import org.apache.camel.impl.engine.DefaultHeadersMapFactory;
+
+                public class Test {
+
+                    CamelContext context;
+
+                    public DefaultHeadersMapFactory test() {
+                        return context.getCamelContextExtension().getHeadersMapFactory();
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testComponenetNameResolverViaPluginHelper() {
+        rewriteRun(
+                java("""
+                            package org.apache.camel.quarkus.component.test.it;
+
+                            import org.apache.camel.CamelContext;
+                            import org.apache.camel.ExtendedCamelContext;
+                            import org.apache.camel.spi.ComponentNameResolver;
+
+                            public class Test {
+
+                                CamelContext context;
+
+                                public void test() {
+                                    ComponentNameResolver ec = context.getExtension(ExtendedCamelContext.class).getComponentNameResolver();
+                                }
+                            }
+                        """,
+                        """
+                                package org.apache.camel.quarkus.component.test.it;
+
+                                import org.apache.camel.CamelContext;
+                                import org.apache.camel.ExtendedCamelContext;
+                                import org.apache.camel.spi.ComponentNameResolver;
+                                import org.apache.camel.support.PluginHelper;
+
+                                public class Test {
+
+                                    CamelContext context;
+
+                                    public void test() {
+                                        ComponentNameResolver ec = PluginHelper.getComponentNameResolver(context);
+                                    }
+                                }
+                                """));
+    }
+
+    @Test
+    void testRuntimeCatalog() {
+        rewriteRun(java(
+                """
+                            package org.apache.camel.quarkus.component.test.it;
+
+                            import org.apache.camel.CamelContext;
+                            import org.apache.camel.catalog.RuntimeCamelCatalog;
+
+                            public class Test {
+
+                                CamelContext context;
+
+                                public void test() {
+                                    final CamelRuntimeCatalog catalog = (CamelRuntimeCatalog) context.getExtension(RuntimeCamelCatalog.class);
+                                }
+                            }
+                        """,
+                """
+                        package org.apache.camel.quarkus.component.test.it;
+
+                        import org.apache.camel.CamelContext;
+                        import org.apache.camel.catalog.RuntimeCamelCatalog;
+
+                        public class Test {
+
+                            CamelContext context;
+
+                            public void test() {
+                                final CamelRuntimeCatalog catalog = (CamelRuntimeCatalog) context.getCamelContextExtension().getContextPlugin(RuntimeCamelCatalog.class);
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void testAdaptRouteDefinition() {
+        rewriteRun(java(
+                """
+                        package org.apache.camel.quarkus.component.test.it;
+
+                        import org.apache.camel.CamelContext;
+                        import org.apache.camel.model.ModelCamelContext;
+                        import org.apache.camel.impl.engine.DefaultHeadersMapFactory;
+
+                        public class Test {
+
+                            CamelContext context;
+
+                            public DefaultHeadersMapFactory test() {
+                                AdviceWith.adviceWith(context.adapt(ModelCamelContext.class).getRouteDefinition("forMocking"), context, null);
+                            }
+                        }
+                        """,
+                """
+                        package org.apache.camel.quarkus.component.test.it;
+
+                        import org.apache.camel.CamelContext;
+                        import org.apache.camel.model.ModelCamelContext;
+                        import org.apache.camel.impl.engine.DefaultHeadersMapFactory;
+
+                        public class Test {
+
+                            CamelContext context;
+
+                            public DefaultHeadersMapFactory test() {
+                                AdviceWith.adviceWith(((ModelCamelContext)context).getRouteDefinition("forMocking"), context, null);
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void testDecoupleExtendedCamelContext() {
+        rewriteRun(java("""
+                import org.apache.camel.CamelContext;
+                import org.apache.camel.ExtendedCamelContext;
+
+                public class Test {
+
+                    CamelContext getCamelContext() {
+                        return null;
+                    }
+
+                    public Object test() {
+                        return getCamelContext().adapt(ExtendedCamelContext.class).getPeriodTaskScheduler();
+                    }
+                }
+                """, """
+                import org.apache.camel.CamelContext;
+
+                public class Test {
+
+                    CamelContext getCamelContext() {
+                        return null;
+                    }
+
+                    public Object test() {
+                        return getCamelContext().getCamelContextExtension().getPeriodTaskScheduler();
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testDecoupleExtendedExchange() {
+        rewriteRun(java("""
+                import org.apache.camel.Exchange;
+                import org.apache.camel.ExtendedExchange;
+                import org.apache.camel.spi.Synchronization;
+
+                public class Test {
+
+                    Exchange exchange;
+                    Synchronization onCompletion;
+
+                    public void test() {
+                          // add exchange callback
+                          exchange.adapt(ExtendedExchange.class).addOnCompletion(onCompletion);
+                    }
+                }
+                """, """
+                import org.apache.camel.Exchange;
+                import org.apache.camel.spi.Synchronization;
+
+                public class Test {
+
+                    Exchange exchange;
+                    Synchronization onCompletion;
+
+                    public void test() {
+                          // add exchange callback
+                          exchange.getExchangeExtension().addOnCompletion(onCompletion);
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testDecoupleExtendedExchange2() {
+        rewriteRun(java("""
+                import org.apache.camel.CamelContext;
+                import org.apache.camel.catalog.RuntimeCamelCatalog;
+
+                public class Test {
+
+                    CamelContext context;
+
+                    public void test() {
+                          final Something catalog = (Something) context.getExtension(RuntimeCamelCatalog.class);
+                    }
+                }
+                """,
+                """
+                        import org.apache.camel.CamelContext;
+                        import org.apache.camel.catalog.RuntimeCamelCatalog;
+
+                        public class Test {
+
+                            CamelContext context;
+
+                            public void test() {
+                                  final Something catalog = (Something) context.getCamelContextExtension().getContextPlugin(RuntimeCamelCatalog.class);
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void testExchangeIsFailureHandled() {
+        rewriteRun(java("""
+                import org.apache.camel.Exchange;
+                import org.apache.camel.ExchangePropertyKey;
+
+                public class Test {
+
+                    Exchange exchange;
+
+                    public void test() {
+                        boolean failureHandled = exchange.getProperty(ExchangePropertyKey.FAILURE_HANDLED);
+                        exchange.removeProperty(ExchangePropertyKey.FAILURE_HANDLED);
+                        exchange.setProperty(ExchangePropertyKey.FAILURE_HANDLED, failureHandled);
+                    }
+                }
+                """, """
+                import org.apache.camel.Exchange;
+
+                public class Test {
+
+                    Exchange exchange;
+
+                    public void test() {
+                        boolean failureHandled = exchange.getExchangeExtension().isFailureHandled();
+                        exchange.getExchangeExtension().setFailureHandled(false);
+                        exchange.getExchangeExtension().setFailureHandled(failureHandled);
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testThreadPoolRejectedPolicy() {
+        rewriteRun(spec -> spec.expectedCyclesThatMakeChanges(2), java("""
+                import org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy;
+
+                import static org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy.Discard;
+                import static org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy.DiscardOldest;
+
+                public class Test {
+
+                    public void test() {
+                        ThreadPoolRejectedPolicy policy = ThreadPoolRejectedPolicy.Discard;
+                        ThreadPoolRejectedPolicy policy2 = Discard;
+                        ThreadPoolRejectedPolicy policy3 = ThreadPoolRejectedPolicy.DiscardOldest;
+                        ThreadPoolRejectedPolicy policy4 = DiscardOldest;
+                    }
+                }
+                """,
+                """
+                        import org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy;
+
+                        /*'ThreadPoolRejectedPolicy.Discard' has been removed, consider using 'ThreadPoolRejectedPolicy.Abort'.*/import static org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy.Discard;
+                        /*'ThreadPoolRejectedPolicy.DiscardOldest' has been removed, consider using 'ThreadPoolRejectedPolicy.Abort'.*/import static org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy.DiscardOldest;
+
+                        public class Test {
+
+                            public void test() {
+                                ThreadPoolRejectedPolicy policy = /*'ThreadPoolRejectedPolicy.Discard' has been removed, consider using 'ThreadPoolRejectedPolicy.Abort'.*/ThreadPoolRejectedPolicy.Discard;
+                                ThreadPoolRejectedPolicy policy2 = Discard;
+                                ThreadPoolRejectedPolicy policy3 = /*'ThreadPoolRejectedPolicy.DiscardOldest' has been removed, consider using 'ThreadPoolRejectedPolicy.Abort'.*/ThreadPoolRejectedPolicy.DiscardOldest;
+                                ThreadPoolRejectedPolicy policy4 = DiscardOldest;
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void testSimpleBuilder() {
+        rewriteRun(spec -> spec.expectedCyclesThatMakeChanges(2), java("""
+                import org.apache.camel.builder.SimpleBuilder;
+                """,
+                """
+                          /*'java.beans.SimpleBeanInfo' has been removed, (class was used internally).*/import org.apache.camel.builder.SimpleBuilder;
+                        """));
+    }
+
+    @Test
+    void testOneIntrospectionSupport() {
+        rewriteRun(spec -> CamelQuarkusTestUtil.recipe(spec, "org.openrewrite.java.camel.migrate.ChangeTypes"),
+                java("""
+                    import org.apache.camel.support.IntrospectionSupport;
+                    
+                    import static org.apache.camel.support.IntrospectionSupport;
+
+                    
+                    public class Test {
+
+                            public void test() {
+                                IntrospectionSupport is;
+                            }
+                        }                                
+                """, """
+                    import org.apache.camel.impl.engine.IntrospectionSupport;
+
+                    public class Test {
+
+                            public void test() {
+                                IntrospectionSupport is;
+                            }
+                        }                       
+                """));
+    }
+
+    @Test
+    void testMultiIntrospectionSupport() {
+        rewriteRun(spec -> CamelQuarkusTestUtil.recipe(spec, "org.openrewrite.java.camel.migrate.ChangeTypes"),
+                java("""
+                    import org.apache.camel.support.IntrospectionSupport;
+
+                    import static org.apache.camel.support.IntrospectionSupport.getGetterShorthandName;
+                    import static org.apache.camel.support.IntrospectionSupport.isGetter;
+                    import static org.apache.camel.support.IntrospectionSupport.isSetter;
+                    
+                    public class Test {
+
+                        public void test() {
+                            IntrospectionSupport is;
+                            isGetter(null);
+                            isSetter(null);
+                            getGetterShorthandName(null);
+                        }
+                    }   
+                """, """
+                    import org.apache.camel.impl.engine.IntrospectionSupport;
+
+                    import static org.apache.camel.impl.engine.IntrospectionSupport.*;
+                    
+                    public class Test {
+
+                        public void test() {
+                            IntrospectionSupport is;
+                            isGetter(null);
+                            isSetter(null);
+                            getGetterShorthandName(null);
+                        }
+                    }   
+                """));
+    }
+
+    @Test
+    void testarchetypeCatalogAsXml() {
+        rewriteRun(spec -> spec.expectedCyclesThatMakeChanges(2), java("""
+                    import org.apache.camel.catalog.CamelCatalog;
+
+                    public class Test {
+
+                        static CamelCatalog catalog;
+
+                        public void test() {
+                            String schema = catalog.archetypeCatalogAsXml();
+                        }
+                    }
+                """,
+                """
+                            import org.apache.camel.catalog.CamelCatalog;
+
+                            public class Test {
+
+                                static CamelCatalog catalog;
+
+                                public void test() {
+                                    String schema = /* Method 'archetypeCatalogAsXml' has been removed. */catalog.archetypeCatalogAsXml();
+                                }
+                            }
+                        """));
+    }
+
+    @Test
+    void testMainListenerConfigureImpl() {
+        rewriteRun(spec -> spec.expectedCyclesThatMakeChanges(2), java("""
+                    import org.apache.camel.CamelContext;
+                    import org.apache.camel.main.MainListener;
+
+                    public class Test implements MainListener {
+
+                        @Override
+                        public void configure(CamelContext context) {
+                            //do something
+                        }
+                    }
+                """,
+                """
+                            import org.apache.camel.CamelContext;
+                            import org.apache.camel.main.MainListener;
+
+                            public class Test implements MainListener {
+
+                                /* Method 'configure' was removed from `org.apache.camel.main.MainListener`, consider using 'beforeConfigure' or 'afterConfigure'. */@Override
+                                public void configure(CamelContext context) {
+                                    //do something
+                                }
+                            }
+                        """));
+    }
+
+    @Test
+    void testDumpRoutes() {
+        rewriteRun(spec -> spec.expectedCyclesThatMakeChanges(2), java("""
+                    import org.apache.camel.CamelContext;
+
+                    public class Test {
+                        public void test(CamelContext context) {
+                            boolean dump = context.isDumpRoutes();
+                            context.setDumpRoutes(true);
+                        }
+                    }
+                """,
+                """
+                            import org.apache.camel.CamelContext;
+
+                            public class Test {
+                                public void test(CamelContext context) {
+                                    boolean dump = /* Method 'getDumpRoutes' returns String value ('xml' or 'yaml' or 'false'). */context.getDumpRoutes();
+                                    /* Method 'setDumpRoutes' accepts String parameter ('xml' or 'yaml' or 'false'). */context.setDumpRoutes(true);
+                                }
+                            }
+                        """));
+    }
+
+    @Test
+    void testAdapt3() {
+        rewriteRun(java(
+                """
+                        import jakarta.enterprise.context.ApplicationScoped;
+                        import jakarta.inject.Inject;
+                        import jakarta.ws.rs.Consumes;
+                        import jakarta.ws.rs.GET;
+                        import jakarta.ws.rs.POST;
+                        import jakarta.ws.rs.Path;
+                        import jakarta.ws.rs.PathParam;
+                        import jakarta.ws.rs.core.MediaType;
+
+                        import org.apache.camel.CamelContext;
+                        import org.apache.camel.ProducerTemplate;
+                        import org.apache.camel.builder.AdviceWith;
+                        import org.apache.camel.builder.AdviceWithRouteBuilder;
+                        import org.apache.camel.component.mock.MockEndpoint;
+                        import org.apache.camel.model.ModelCamelContext;
+                        import org.jboss.logging.Logger;
+                        import org.wildfly.common.Assert;
+
+                        public class Test {
+                            public void test(CamelContext context) {
+                                // advice the first route using the inlined AdviceWith route builder
+                                // which has extended capabilities than the regular route builder
+                                AdviceWith.adviceWith(context.adapt(ModelCamelContext.class).getRouteDefinition("forMocking"), context,
+                                        new AdviceWithRouteBuilder() {
+                                            @Override
+                                            public void configure() throws Exception {
+                                                mockEndpoints("direct:mock.*", "log:mock.*");
+                                            }
+                                        });
+                            }
+                        }
+                        """,
+                """
+                                        import jakarta.enterprise.context.ApplicationScoped;
+                                        import jakarta.inject.Inject;
+                                        import jakarta.ws.rs.Consumes;
+                                        import jakarta.ws.rs.GET;
+                                        import jakarta.ws.rs.POST;
+                                        import jakarta.ws.rs.Path;
+                                        import jakarta.ws.rs.PathParam;
+                                        import jakarta.ws.rs.core.MediaType;
+
+                                        import org.apache.camel.CamelContext;
+                                        import org.apache.camel.ProducerTemplate;
+                                        import org.apache.camel.builder.AdviceWith;
+                                        import org.apache.camel.builder.AdviceWithRouteBuilder;
+                                        import org.apache.camel.component.mock.MockEndpoint;
+                                        import org.apache.camel.model.ModelCamelContext;
+                                        import org.jboss.logging.Logger;
+                                        import org.wildfly.common.Assert;
+
+                                        public class Test {
+                                            public void test(CamelContext context) {
+                                                // advice the first route using the inlined AdviceWith route builder
+                                                // which has extended capabilities than the regular route builder
+                                                AdviceWith.adviceWith(((ModelCamelContext)context).getRouteDefinition("forMocking"), context,
+                                                        new AdviceWithRouteBuilder() {
+                                                            @Override
+                                                            public void configure() throws Exception {
+                                                                mockEndpoints("direct:mock.*", "log:mock.*");
+                                                            }
+                                                        });
+                                            }
+                                        }
+                        """));
+    }
+
+    @Test
+    void testBacklogTracerEventMessage() {
+        rewriteRun(java("""
+                import org.apache.camel.api.management.mbean.BacklogTracerEventMessage;
+
+                public class Test  {
+
+                    public void test() {
+                        org.apache.camel.api.management.mbean.BacklogTracerEventMessage msg;
+                    }
+                }
+                """, """
+                import org.apache.camel.spi.BacklogTracerEventMessage;
+
+                public class Test  {
+
+                    public void test() {
+                        org.apache.camel.spi.BacklogTracerEventMessage msg;
+                    }
+                }
+                """));
+    }
+}

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelBeanRecipeTest.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelBeanRecipeTest.java
@@ -1,0 +1,167 @@
+package io.quarkus.updates.camel30;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CamelBeanRecipeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelQuarkusTestUtil.recipe(spec)
+                .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true).classpath("camel-bean"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testClassTypeAndInt() {
+        rewriteRun(java("""
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .to("bean:myBean?method=foo(com.foo.MyOrder, int)");
+                        }
+                    }
+                """, """
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .to("bean:myBean?method=foo(com.foo.MyOrder.class, int.class)");
+                        }
+                    }
+                """
+
+        ));
+    }
+
+    @Test
+    void testClassTypeAndBoolean() {
+        rewriteRun(java("""
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .to("bean:myBean?method=foo(com.foo.MyOrder, true)");
+                        }
+                    }
+                """, """
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .to("bean:myBean?method=foo(com.foo.MyOrder.class, true)");
+                        }
+                    }
+                """
+
+        ));
+    }
+
+    @Test
+    void testClassTypeAndFloat() {
+        rewriteRun(java("""
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .to("bean:myBean?method=foo(com.foo.MyOrder, float)");
+                        }
+                    }
+                """, """
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .to("bean:myBean?method=foo(com.foo.MyOrder.class, float.class)");
+                        }
+                    }
+                """
+
+        ));
+    }
+
+    @Test
+    void testDoubleAndChar() {
+        rewriteRun(java("""
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .to("bean:myBean?method=foo(double, char)");
+                        }
+                    }
+                """, """
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .to("bean:myBean?method=foo(double.class, char.class)");
+                        }
+                    }
+                """
+
+        ));
+    }
+
+    @Test
+    void testMultipleTo() {
+        rewriteRun(java("""
+                import org.apache.camel.builder.RouteBuilder;
+
+                public class MySimpleToDRoute extends RouteBuilder {
+
+                    @Override
+                    public void configure() {
+                        from("direct:a")
+                        .to("bean:myBean?method=foo(double, char)")
+                        .to("bean:myBean?method=bar(float, int)");
+                    }
+                }
+                """, """
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .to("bean:myBean?method=foo(double.class, char.class)")
+                            .to("bean:myBean?method=bar(float.class, int.class)");
+                        }
+                    }
+                """
+
+        ));
+    }
+
+}

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelEIPRecipeTest.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelEIPRecipeTest.java
@@ -1,0 +1,104 @@
+package io.quarkus.updates.camel30;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CamelEIPRecipeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelQuarkusTestUtil.recipe(spec)
+                .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true).classpath("camel-activemq"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testRemovedEIPInOptionalOut() {
+        rewriteRun(java("""
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .inOut("activemq:queue:testqueue")
+                            .to("log:result_a");
+                        }
+                    }
+                """, """
+                    import org.apache.camel.ExchangePattern;
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .setExchangePattern(ExchangePattern.InOut).to("activemq:queue:testqueue")
+                            .to("log:result_a");
+                        }
+                    }
+                """
+
+        ));
+    }
+
+    @Test
+    void testRemovedEIPOutOptionalIn() {
+        rewriteRun(java("""
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .inOut("activemq:queue:testqueue")
+                            .to("log:result_a");
+                        }
+                    }
+                """, """
+                    import org.apache.camel.ExchangePattern;
+                    import org.apache.camel.builder.RouteBuilder;
+
+                    public class MySimpleToDRoute extends RouteBuilder {
+
+                        @Override
+                        public void configure() {
+                            from("direct:a")
+                            .setExchangePattern(ExchangePattern.InOut).to("activemq:queue:testqueue")
+                            .to("log:result_a");
+                        }
+                    }
+                """
+
+        ));
+    }
+
+    @Test
+    void testRemovedEIPOutIn() {
+        rewriteRun(java("""
+                        import org.apache.camel.ExchangePattern;
+                        import org.apache.camel.builder.RouteBuilder;
+
+                        public class MySimpleToDRoute extends RouteBuilder {
+
+                            @Override
+                            public void configure() {
+                                from("direct:a")
+                                .setExchangePattern(ExchangePattern.InOut).to("activemq:queue:testqueue")
+                                .to("log:result_a");
+                            }
+                        }
+                """
+
+        ));
+    }
+
+}

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelHttpTest.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelHttpTest.java
@@ -1,0 +1,101 @@
+package io.quarkus.updates.camel30;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CamelHttpTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelQuarkusTestUtil.recipe(spec)
+                .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true).classpath("camel-api",
+                        "camel-support", "camel-core-model", "camel-util", "camel-catalog", "camel-main", "httpclient"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testHttp() {
+        rewriteRun(java(
+                """
+                            import jakarta.inject.Named;
+
+                            import org.apache.http.HttpHost;
+                            import org.apache.http.auth.AuthScope;
+                            import org.apache.http.auth.UsernamePasswordCredentials;
+                            import org.apache.http.client.protocol.HttpClientContext;
+                            import org.apache.http.impl.auth.BasicScheme;
+                            import org.apache.http.impl.client.BasicAuthCache;
+                            import org.apache.http.impl.client.BasicCredentialsProvider;
+                            import org.apache.http.protocol.HttpContext;
+                            import org.eclipse.microprofile.config.ConfigProvider;
+
+                            import static org.apache.camel.quarkus.component.http.it.HttpResource.USER_ADMIN;
+                            import static org.apache.camel.quarkus.component.http.it.HttpResource.USER_ADMIN_PASSWORD;
+
+                            public class HttpProducers {
+
+                                @Named
+                                HttpContext basicAuthContext() {
+                                    Integer port = ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class);
+
+                                    UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(USER_ADMIN, USER_ADMIN_PASSWORD);
+                                    BasicCredentialsProvider provider = new BasicCredentialsProvider();
+                                    provider.setCredentials(AuthScope.ANY, credentials);
+
+                                    BasicAuthCache authCache = new BasicAuthCache();
+                                    BasicScheme basicAuth = new BasicScheme();
+                                    authCache.put(new HttpHost("localhost", port), basicAuth);
+
+                                    HttpClientContext context = HttpClientContext.create();
+                                    context.setAuthCache(authCache);
+                                    context.setCredentialsProvider(provider);
+
+                                    return context;
+                                }
+                            }
+                        """,
+                """
+                            import jakarta.inject.Named;
+
+                            import org.apache.hc.core5.http.HttpHost;
+                            import org.apache.hc.client5.http.auth.AuthScope;
+                            import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+                            import org.apache.hc.client5.http.protocol.HttpClientContext;
+                            import org.apache.hc.client5.http.impl.auth.BasicScheme;
+                            import org.apache.hc.client5.http.impl.auth.BasicAuthCache;
+                            import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+                            import org.apache.hc.core5.http.protocol.HttpContext;
+                            import org.eclipse.microprofile.config.ConfigProvider;
+
+                            import static org.apache.camel.quarkus.component.http.it.HttpResource.USER_ADMIN;
+                            import static org.apache.camel.quarkus.component.http.it.HttpResource.USER_ADMIN_PASSWORD;
+
+                            public class HttpProducers {
+
+                                @Named
+                                HttpContext basicAuthContext() {
+                                    Integer port = ConfigProvider.getConfig().getValue("quarkus.http.test-port", Integer.class);
+
+                                    UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(USER_ADMIN, USER_ADMIN_PASSWORD);
+                                    BasicCredentialsProvider provider = new BasicCredentialsProvider();
+                                    provider.setCredentials(new AuthScope(null, -1), credentials);
+
+                                    BasicAuthCache authCache = new BasicAuthCache();
+                                    BasicScheme basicAuth = new BasicScheme();
+                                    authCache.put(new HttpHost("localhost", port), basicAuth);
+
+                                    HttpClientContext context = HttpClientContext.create();
+                                    context.setAuthCache(authCache);
+                                    context.setCredentialsProvider(provider);
+
+                                    return context;
+                                }
+                            }
+                        """));
+    }
+}

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelPomRecipeTest.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelPomRecipeTest.java
@@ -1,0 +1,707 @@
+package io.quarkus.updates.camel30;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CamelPomRecipeTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelQuarkusTestUtil.recipe(spec, "org.openrewrite.java.camel.migrate.removedExtensions")
+                .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testRemovedExtensions() {
+        rewriteRun(pomXml(
+                """
+                        <project>
+                           <modelVersion>4.0.0</modelVersion>
+
+                           <artifactId>test</artifactId>
+                           <groupId>org.apache.camel.quarkus.test</groupId>
+                           <version>1.0.0</version>
+
+                           <properties>
+                               <quarkus.platform.version>2.13.3.Final</quarkus.platform.version>
+                           </properties>
+
+                           <dependencyManagement>
+                               <dependencies>
+                                   <dependency>
+                                       <groupId>io.quarkus.platform</groupId>
+                                       <artifactId>quarkus-camel-bom</artifactId>
+                                       <version>2.13.7.Final</version>
+                                       <type>pom</type>
+                                       <scope>import</scope>
+                                   </dependency>
+                               </dependencies>
+                           </dependencyManagement>
+
+                           <dependencies>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-activemq</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-atmos</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-avro-rpc</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-caffeine-lrucache</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-datasonnet</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-bean</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-dozer</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-elasticsearch-rest</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-hbase</artifactId>
+                               </dependency>
+                               <!--<dependency>  org.openrewrite.maven.MavenDownloadingException: org.iota:java-md-doclet:2.2 failed. Unable to download POM. Tried repositories:
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-iota</artifactId>
+                               </dependency>-->
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-jbpm</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-jclouds</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-johnzon</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-microprofile-metrics</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-milo</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-opentracing</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-optaplanner</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-rabbitmq</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-smallrye-reactive-messaging</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-solr</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-tika</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-vm</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-xmlsecurity</artifactId>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-xstream</artifactId>
+                               </dependency>
+                           </dependencies>
+
+                        </project>
+                                                        """,
+                """
+                        <project>
+                           <modelVersion>4.0.0</modelVersion>
+
+                           <artifactId>test</artifactId>
+                           <groupId>org.apache.camel.quarkus.test</groupId>
+                           <version>1.0.0</version>
+
+                           <properties>
+                               <quarkus.platform.version>2.13.3.Final</quarkus.platform.version>
+                           </properties>
+
+                           <dependencyManagement>
+                               <dependencies>
+                                   <dependency>
+                                       <groupId>io.quarkus.platform</groupId>
+                                       <artifactId>quarkus-camel-bom</artifactId>
+                                       <version>2.13.7.Final</version>
+                                       <type>pom</type>
+                                       <scope>import</scope>
+                                   </dependency>
+                               </dependencies>
+                           </dependencyManagement>
+
+                           <dependencies>
+                               <dependency>
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-bean</artifactId>
+                               </dependency>
+                               <!--<dependency>  org.openrewrite.maven.MavenDownloadingException: org.iota:java-md-doclet:2.2 failed. Unable to download POM. Tried repositories:
+                                   <groupId>org.apache.camel.quarkus</groupId>
+                                   <artifactId>camel-quarkus-iota</artifactId>
+                               </dependency>-->
+                           </dependencies>
+
+                        </project>
+                                                        """));
+    }
+
+    @Test
+    void testRemovedComponentsReal() {
+        rewriteRun(pomXml(
+                """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <!--
+
+                            Licensed to the Apache Software Foundation (ASF) under one or more
+                            contributor license agreements.  See the NOTICE file distributed with
+                            this work for additional information regarding copyright ownership.
+                            The ASF licenses this file to You under the Apache License, Version 2.0
+                            (the "License"); you may not use this file except in compliance with
+                            the License.  You may obtain a copy of the License at
+
+                                 http://www.apache.org/licenses/LICENSE-2.0
+
+                            Unless required by applicable law or agreed to in writing, software
+                            distributed under the License is distributed on an "AS IS" BASIS,
+                            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                            See the License for the specific language governing permissions and
+                            limitations under the License.
+
+                        -->
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                            <modelVersion>4.0.0</modelVersion>
+                            
+                            <groupId>org.apache.camel.quarkus</groupId>
+                            <version>2.13.3</version>
+
+                            <artifactId>camel-quarkus-migration-test-microprofile</artifactId>
+                            <name>Camel Quarkus :: Migration Tests :: MicroProfile</name>
+                            <description>Migration tests for Camel Quarkus MicroProfile extensions</description>
+
+                            <properties>
+
+                                <quarkus.version>2.13.8.Final</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
+                                <!-- Allow running our tests against alternative BOMs, such as io.quarkus.platform:quarkus-camel-bom https://repo1.maven.org/maven2/io/quarkus/platform/quarkus-camel-bom/ -->
+                                <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+                                <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+                                <quarkus.platform.version>${quarkus.version}</quarkus.platform.version>
+                                <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+                                <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+                                <camel-quarkus.platform.version>2.13.3</camel-quarkus.platform.version>
+                                <camel-quarkus.version>2.13.3</camel-quarkus.version><!-- This needs to be set to the underlying CQ version from command line when testing against Platform BOMs -->
+
+                                <quarkus.banner.enabled>false</quarkus.banner.enabled>
+                                <maven.compiler.source>17</maven.compiler.source>
+                                <maven.compiler.target>17</maven.compiler.target>
+                            </properties>
+
+                            <dependencyManagement>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>${quarkus.platform.group-id}</groupId>
+                                        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                                        <version>${quarkus.platform.version}</version>
+                                        <type>pom</type>
+                                        <scope>import</scope>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>${camel-quarkus.platform.group-id}</groupId>
+                                        <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
+                                        <version>${camel-quarkus.platform.version}</version>
+                                        <type>pom</type>
+                                        <scope>import</scope>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.apache.camel.quarkus</groupId>
+                                        <artifactId>camel-quarkus-bom-test</artifactId>
+                                        <version>${camel-quarkus.version}</version>
+                                        <type>pom</type>
+                                        <scope>import</scope>
+                                    </dependency>
+                                </dependencies>
+                            </dependencyManagement>
+
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-bean</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-direct</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-log</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-microprofile-fault-tolerance</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-microprofile-health</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-microprofile-metrics</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-mock</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-resteasy</artifactId>
+                                </dependency>
+
+                                <!-- test dependencies -->
+                                <dependency>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-junit5</artifactId>
+                                    <scope>test</scope>
+                                </dependency>
+                                <dependency>
+                                    <groupId>io.rest-assured</groupId>
+                                    <artifactId>rest-assured</artifactId>
+                                    <scope>test</scope>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.awaitility</groupId>
+                                    <artifactId>awaitility</artifactId>
+                                    <scope>test</scope>
+                                </dependency>
+                            </dependencies>
+
+
+                            <profiles>
+                                <profile>
+                                    <id>native</id>
+                                    <activation>
+                                        <property>
+                                            <name>native</name>
+                                        </property>
+                                    </activation>
+                                    <properties>
+                                        <quarkus.package.type>native</quarkus.package.type>
+                                    </properties>
+                                    <build>
+                                        <plugins>
+                                            <plugin>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-failsafe-plugin</artifactId>
+                                                <executions>
+                                                    <execution>
+                                                        <goals>
+                                                            <goal>integration-test</goal>
+                                                            <goal>verify</goal>
+                                                        </goals>
+                                                    </execution>
+                                                </executions>
+                                            </plugin>
+                                        </plugins>
+                                    </build>
+                                </profile>
+                                <profile>
+                                    <id>virtualDependencies</id>
+                                    <activation>
+                                        <property>
+                                            <name>!noVirtualDependencies</name>
+                                        </property>
+                                    </activation>
+                                    <dependencies>
+                                        <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-bean-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-direct-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-log-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-microprofile-fault-tolerance-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-microprofile-health-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-microprofile-metrics-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-mock-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                    </dependencies>
+                                </profile>
+                            </profiles>
+
+                        </project>
+                                                        """,
+                """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <!--
+
+                            Licensed to the Apache Software Foundation (ASF) under one or more
+                            contributor license agreements.  See the NOTICE file distributed with
+                            this work for additional information regarding copyright ownership.
+                            The ASF licenses this file to You under the Apache License, Version 2.0
+                            (the "License"); you may not use this file except in compliance with
+                            the License.  You may obtain a copy of the License at
+
+                                 http://www.apache.org/licenses/LICENSE-2.0
+
+                            Unless required by applicable law or agreed to in writing, software
+                            distributed under the License is distributed on an "AS IS" BASIS,
+                            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                            See the License for the specific language governing permissions and
+                            limitations under the License.
+
+                        -->
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                            <modelVersion>4.0.0</modelVersion>
+                                
+                            <groupId>org.apache.camel.quarkus</groupId>
+                            <version>2.13.3</version>
+
+                            <artifactId>camel-quarkus-migration-test-microprofile</artifactId>
+                            <name>Camel Quarkus :: Migration Tests :: MicroProfile</name>
+                            <description>Migration tests for Camel Quarkus MicroProfile extensions</description>
+
+                            <properties>
+
+                                <quarkus.version>2.13.8.Final</quarkus.version><!-- https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/ -->
+                                <!-- Allow running our tests against alternative BOMs, such as io.quarkus.platform:quarkus-camel-bom https://repo1.maven.org/maven2/io/quarkus/platform/quarkus-camel-bom/ -->
+                                <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+                                <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+                                <quarkus.platform.version>${quarkus.version}</quarkus.platform.version>
+                                <camel-quarkus.platform.group-id>org.apache.camel.quarkus</camel-quarkus.platform.group-id>
+                                <camel-quarkus.platform.artifact-id>camel-quarkus-bom</camel-quarkus.platform.artifact-id>
+                                <camel-quarkus.platform.version>2.13.3</camel-quarkus.platform.version>
+                                <camel-quarkus.version>2.13.3</camel-quarkus.version><!-- This needs to be set to the underlying CQ version from command line when testing against Platform BOMs -->
+
+                                <quarkus.banner.enabled>false</quarkus.banner.enabled>
+                                <maven.compiler.source>17</maven.compiler.source>
+                                <maven.compiler.target>17</maven.compiler.target>
+                            </properties>
+
+                            <dependencyManagement>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>${quarkus.platform.group-id}</groupId>
+                                        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                                        <version>${quarkus.platform.version}</version>
+                                        <type>pom</type>
+                                        <scope>import</scope>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>${camel-quarkus.platform.group-id}</groupId>
+                                        <artifactId>${camel-quarkus.platform.artifact-id}</artifactId>
+                                        <version>${camel-quarkus.platform.version}</version>
+                                        <type>pom</type>
+                                        <scope>import</scope>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.apache.camel.quarkus</groupId>
+                                        <artifactId>camel-quarkus-bom-test</artifactId>
+                                        <version>${camel-quarkus.version}</version>
+                                        <type>pom</type>
+                                        <scope>import</scope>
+                                    </dependency>
+                                </dependencies>
+                            </dependencyManagement>
+
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-bean</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-direct</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-log</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-microprofile-fault-tolerance</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-microprofile-health</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <artifactId>camel-quarkus-mock</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-resteasy</artifactId>
+                                </dependency>
+
+                                <!-- test dependencies -->
+                                <dependency>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-junit5</artifactId>
+                                    <scope>test</scope>
+                                </dependency>
+                                <dependency>
+                                    <groupId>io.rest-assured</groupId>
+                                    <artifactId>rest-assured</artifactId>
+                                    <scope>test</scope>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.awaitility</groupId>
+                                    <artifactId>awaitility</artifactId>
+                                    <scope>test</scope>
+                                </dependency>
+                            </dependencies>
+
+
+                            <profiles>
+                                <profile>
+                                    <id>native</id>
+                                    <activation>
+                                        <property>
+                                            <name>native</name>
+                                        </property>
+                                    </activation>
+                                    <properties>
+                                        <quarkus.package.type>native</quarkus.package.type>
+                                    </properties>
+                                    <build>
+                                        <plugins>
+                                            <plugin>
+                                                <groupId>org.apache.maven.plugins</groupId>
+                                                <artifactId>maven-failsafe-plugin</artifactId>
+                                                <executions>
+                                                    <execution>
+                                                        <goals>
+                                                            <goal>integration-test</goal>
+                                                            <goal>verify</goal>
+                                                        </goals>
+                                                    </execution>
+                                                </executions>
+                                            </plugin>
+                                        </plugins>
+                                    </build>
+                                </profile>
+                                <profile>
+                                    <id>virtualDependencies</id>
+                                    <activation>
+                                        <property>
+                                            <name>!noVirtualDependencies</name>
+                                        </property>
+                                    </activation>
+                                    <dependencies>
+                                        <!-- The following dependencies guarantee that this module is built after them. You can update them by running `mvn process-resources -Pformat -N` from the source tree root directory -->
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-bean-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-direct-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-log-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-microprofile-fault-tolerance-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-microprofile-health-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-microprofile-metrics-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-mock-deployment</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>pom</type>
+                                            <scope>test</scope>
+                                            <exclusions>
+                                                <exclusion>
+                                                    <groupId>*</groupId>
+                                                    <artifactId>*</artifactId>
+                                                </exclusion>
+                                            </exclusions>
+                                        </dependency>
+                                    </dependencies>
+                                </profile>
+                            </profiles>
+
+                        </project>
+                                                        """));
+    }
+}

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelQuarkusTestUtil.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelQuarkusTestUtil.java
@@ -1,0 +1,14 @@
+package io.quarkus.updates.camel30;
+
+import org.openrewrite.test.RecipeSpec;
+
+public class CamelQuarkusTestUtil {
+
+    public static RecipeSpec recipe(RecipeSpec spec) {
+        return recipe(spec, "io.quarkus.updates.camel30.CamelQuarkusMigrationRecipe");
+    }
+
+    public static RecipeSpec recipe(RecipeSpec spec, String... activerecipes) {
+        return spec.recipeFromResource("/quarkus-updates/org.apache.camel.quarkus/camel-quarkus-core/3alpha.yaml", activerecipes);
+    }
+}

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelYamlTest.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelYamlTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.quarkus.updates.camel30;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+import org.openrewrite.yaml.Assertions;
+
+public class CamelYamlTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelQuarkusTestUtil.recipe(spec)
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testStepsToFrom1() {
+        rewriteRun(Assertions.yaml("""
+                  route:
+                    from:
+                      uri: "direct:info"
+                    steps:
+                      log: "message"
+                """, """
+                  route:
+                    from:
+                      uri: "direct:info"
+                      steps:
+                        log: "message"
+                """));
+    }
+
+    @Test
+    void testStepsToFrom2() {
+        rewriteRun(Assertions.yaml("""
+                    from:
+                      uri: "direct:info"
+                    steps:
+                      log: "message"
+                """, """
+                    from:
+                      uri: "direct:info"
+                      steps:
+                        log: "message"
+                """));
+    }
+
+    @Test
+    void testStepsToFrom3() {
+        rewriteRun(Assertions.yaml("""
+                - from:
+                    uri: "direct:start"
+                  steps:
+                  - filter:
+                      expression:
+                        simple: "${in.header.continue} == true"
+                      steps:
+                        - to:
+                            uri: "log:filtered"
+                  - to:
+                      uri: "log:original"
+                """, """
+                  - from:
+                      uri: "direct:start"
+                      steps:
+                        - filter:
+                            expression:
+                              simple: "${in.header.continue} == true"
+                            steps:
+                              - to:
+                                  uri: "log:filtered"
+                        - to:
+                            uri: "log:original"
+                """));
+    }
+
+    @Test
+    void testRouteConfigurationWithOnException() {
+        rewriteRun(Assertions.yaml("""
+                - route-configuration:
+                    - id: "yamlRouteConfiguration"
+                    - on-exception:
+                        handled:
+                          constant: "true"
+                        exception:
+                          - "org.apache.camel.quarkus.core.it.routeconfigurations.RouteConfigurationsException"
+                        steps:
+                          - set-body:
+                              constant:
+                                  expression: "onException has been triggered in yamlRouteConfiguration"
+                """, """
+                  - route-configuration:
+                      id: "yamlRouteConfiguration"
+                      on-exception:
+                        - on-exception:
+                            handled:
+                              constant: "true"
+                            exception:
+                              - "org.apache.camel.quarkus.core.it.routeconfigurations.RouteConfigurationsException"
+                            steps:
+                              - set-body:
+                                  constant:
+                                    expression: "onException has been triggered in yamlRouteConfiguration"
+                """));
+    }
+
+    @Test
+    void testRouteConfigurationWithoutOnException() {
+        rewriteRun(Assertions.yaml("""
+                - route-configuration:
+                    - id: "__id"
+                """, """
+                  - route-configuration:
+                      id: "__id"
+                """));
+    }
+
+    @Test
+    void testDoubleDocument() {
+        rewriteRun(Assertions.yaml("""
+                - route-configuration:
+                    - id: "yamlRouteConfiguration1"
+                    - on-exception:
+                        handled:
+                          constant: "true"
+                        exception:
+                          - "org.apache.camel.quarkus.core.it.routeconfigurations.RouteConfigurationsException"
+                        steps:
+                          - set-body:
+                              constant:
+                                  expression: "onException has been triggered in yamlRouteConfiguration"
+                ---
+                - route-configuration:
+                    - id: "yamlRouteConfiguration2"
+                    - on-exception:
+                        handled:
+                          constant: "true"
+                        exception:
+                          - "org.apache.camel.quarkus.core.it.routeconfigurations.RouteConfigurationsException"
+                        steps:
+                          - set-body:
+                              constant:
+                                  expression: "onException has been triggered in yamlRouteConfiguration"
+                """, """
+                  - route-configuration:
+                      id: "yamlRouteConfiguration1"
+                      on-exception:
+                        - on-exception:
+                            handled:
+                              constant: "true"
+                            exception:
+                              - "org.apache.camel.quarkus.core.it.routeconfigurations.RouteConfigurationsException"
+                            steps:
+                              - set-body:
+                                  constant:
+                                    expression: "onException has been triggered in yamlRouteConfiguration"
+                  ---
+                  - route-configuration:
+                      id: "yamlRouteConfiguration2"
+                      on-exception:
+                        - on-exception:
+                            handled:
+                              constant: "true"
+                            exception:
+                              - "org.apache.camel.quarkus.core.it.routeconfigurations.RouteConfigurationsException"
+                            steps:
+                              - set-body:
+                                  constant:
+                                    expression: "onException has been triggered in yamlRouteConfiguration"
+                """));
+    }
+
+    @Test
+    void testDoubleDocumentSimple() {
+        rewriteRun(Assertions.yaml("""
+                - route-configuration:
+                    - id: "__id1"
+                ---
+                - route-configuration:
+                    - id: "__id2"
+                """, """
+                  - route-configuration:
+                      id: "__id1"
+                  ---
+                  - route-configuration:
+                      id: "__id2"
+                """));
+    }
+
+    @Test
+    void testRouteConfigurationIdempotent() {
+        rewriteRun(Assertions.yaml("""
+                  - route-configuration:
+                      id: "yamlRouteConfiguration"
+                      on-exception:
+                        - on-exception:
+                            handled:
+                              constant: "true"
+                            exception:
+                              - "org.apache.camel.quarkus.core.it.routeconfigurations.RouteConfigurationsException"
+                            steps:
+                              - set-body:
+                                  constant:
+                                    expression: "onException has been triggered in yamlRouteConfiguration"
+                """));
+    }
+}

--- a/recipes/src/main/java/io/quarkus/updates/camel30/AbstractCamelQuarkusJavaVisitor.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/AbstractCamelQuarkusJavaVisitor.java
@@ -1,0 +1,155 @@
+package io.quarkus.updates.camel30;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Parent of Camel visitors, skips visit methods in case that there is no camel package imported.
+ * <p>
+ * Every method <i>visit*</i> is marked as final and methods <i>doVisit*</i> are used instead.
+ * </p>
+ * <p>
+ * Simple cache for methodMatchers is implemented here. Usage: call <i>MethodMatcher getMethodMatcher(String signature)</i>.
+ * </p>
+ */
+public abstract class AbstractCamelQuarkusJavaVisitor extends JavaIsoVisitor<ExecutionContext> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCamelQuarkusJavaVisitor.class);
+    //flag that camel package is imported to the file
+    private boolean camel = false;
+
+    private LinkedList<JavaType> implementsList = new LinkedList<>();
+
+    //There is no need to  initialize all patterns at the class start.
+    //Map is a cache for created patterns
+    private static Map<String, MethodMatcher> methodMatchers = new HashMap();
+
+    @Override
+    public final J.Import visitImport(J.Import _import, ExecutionContext context) {
+        //if there is at least one import of camel class, the camel recipe should be executed
+        if(_import.getTypeName().contains("org.apache.camel")) {
+            camel = true;
+        }
+
+        if(!camel) {
+            //skip recipe if file does not contain camel
+            return _import;
+        }
+
+        return executeVisitWithCatch(() -> doVisitImport(_import, context), _import, context);
+    }
+
+    @Override
+    public final J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext context) {
+        if (classDecl.getImplements() != null && !classDecl.getImplements().isEmpty()) {
+            implementsList.addAll(classDecl.getImplements().stream().map(i -> i.getType()).collect(Collectors.toList()));
+        }
+        return executeVisitWithCatch(() -> doVisitClassDeclaration(classDecl, context), classDecl, context);
+    }
+
+    @Override
+    public final J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext context) {
+        if(!camel) {
+            //skip recipe if file does not contain camel
+            return fieldAccess;
+        }
+
+        return executeVisitWithCatch(() -> doVisitFieldAccess(fieldAccess, context), fieldAccess, context);
+    }
+
+    @Override
+    public final J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext context) {
+        if(!camel) {
+            //skip recipe if file does not contain camel
+            return method;
+        }
+
+        return executeVisitWithCatch(() -> doVisitMethodDeclaration(method, context), method, context);
+    }
+
+    @Override
+    public final J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext context) {
+        if(!camel) {
+            //skip recipe if file does not contain camel
+            return method;
+        }
+
+        return executeVisitWithCatch(() -> doVisitMethodInvocation(method, context), method, context);
+    }
+
+    @Override
+    public final J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext context) {
+        if(!camel) {
+            //skip recipe if file does not contain camel
+            return annotation;
+        }
+
+        return executeVisitWithCatch(() -> doVisitAnnotation(annotation, context), annotation, context);
+    }
+
+
+    //-------------------------------- internal methods used by children---------------------------------
+
+    protected  J.Import doVisitImport(J.Import _import, ExecutionContext context) {
+        return super.visitImport(_import, context);
+     }
+
+    protected J.ClassDeclaration doVisitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext context) {
+        return super.visitClassDeclaration(classDecl, context);
+     }
+
+    protected J.FieldAccess doVisitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext context) {
+        return super.visitFieldAccess(fieldAccess, context);
+    }
+
+    protected J.MethodDeclaration doVisitMethodDeclaration(J.MethodDeclaration method, ExecutionContext context) {
+        return super.visitMethodDeclaration(method, context);
+    }
+
+    protected J.MethodInvocation doVisitMethodInvocation(J.MethodInvocation method, ExecutionContext context) {
+        return super.visitMethodInvocation(method, context);
+    }
+
+    protected J.Annotation doVisitAnnotation(J.Annotation annotation, ExecutionContext context) {
+        return super.visitAnnotation(annotation, context);
+    }
+
+     // ------------------------------------------ helper methods -------------------------------------------
+
+    protected LinkedList<JavaType> getImplementsList() {
+        return implementsList;
+    }
+
+    // If the migration fails - do not fail whole migration process, only this one recipe
+    protected <T extends J> T executeVisitWithCatch(Supplier<T> visitMethod, T origValue, ExecutionContext context) {
+        try {
+            return visitMethod.get();
+        } catch (Exception e) {
+            LOGGER.warn(String.format("Internal error detected in %s, recipe is skipped.",context.getMessage("org.openrewrite.currentRecipe").getClass().getSimpleName()), e);
+            return origValue;
+        }
+    }
+
+    protected MethodMatcher getMethodMatcher(String signature) {
+        synchronized (methodMatchers) {
+            MethodMatcher matcher = methodMatchers.get(signature);
+
+            if (matcher == null) {
+                matcher = new MethodMatcher(signature);
+                methodMatchers.put(signature, matcher);
+            }
+
+            return matcher;
+        }
+    }
+}

--- a/recipes/src/main/java/io/quarkus/updates/camel30/RecipesUtil.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/RecipesUtil.java
@@ -1,0 +1,245 @@
+package io.quarkus.updates.camel30;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.xml.tree.Xml;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static org.openrewrite.Tree.randomId;
+
+public class RecipesUtil {
+
+    private static String CAMEL_PRESENT_KEY = RecipesUtil.class.getSimpleName();
+
+    //---------------- annotations helpers
+
+    public static J.Annotation createAnnotation(J.Annotation annotation, String name, Function<String, Boolean> argMatcher, String args) {
+
+        LinkedList<Expression> originalArguments = annotation.getArguments() == null ? new LinkedList<>() : new LinkedList(annotation.getArguments());
+
+        String newArgName = args.replaceAll("=.*", "").trim();
+
+        //remove argument with the same name as the new one
+        if(argMatcher == null) {
+            originalArguments.add(new J.Empty(randomId(), Space.format(args), Markers.EMPTY));
+        } else {
+            for (ListIterator<Expression> iter = originalArguments.listIterator(); iter.hasNext(); ) {
+                Expression expr = iter.next();
+                if (argMatcher.apply(expr.toString().replaceAll("\\s", ""))) {
+                    iter.set(new J.Empty(randomId(), Space.format(args), Markers.EMPTY));
+                }
+            }
+        }
+
+        //construct arguments for the new annotation
+        List<JRightPadded<Expression>> newArgs = new LinkedList<>();
+        for(Expression e: originalArguments) {
+            newArgs.add(new JRightPadded(e, Space.EMPTY, Markers.EMPTY));
+        }
+
+        J.Identifier newAnnotationIdentifier =  new J.Identifier(randomId(), annotation.getPrefix(), Markers.EMPTY, name,
+                JavaType.ShallowClass.build("java.lang.Object"), null);
+        JContainer<Expression> arguments = JContainer.build(
+                Space.EMPTY,
+                newArgs,
+                Markers.EMPTY);
+        return new J.Annotation(UUID.randomUUID(), annotation.getPrefix(), Markers.EMPTY,
+                newAnnotationIdentifier, arguments);
+    }
+
+    public static Optional<String> getValueOfArgs(List<Expression> expressions, String parameter) {
+        if(expressions == null || expressions.isEmpty()) {
+            return Optional.empty();
+        }
+       return expressions.stream()
+               .filter(e -> e.toString().replaceAll("\\s", "").startsWith(parameter + "="))
+               .map(e -> e.toString().replaceAll("\\s", "").replaceFirst(parameter + "=", ""))
+               .findFirst();
+    }
+
+    //-------------- methods helping with comments ----
+
+    public static Comment createMultinlineComment(String text) {
+        return new TextComment(true, text, null, Markers.EMPTY);
+    }
+    public static Comment createComment(String text) {
+        return new TextComment(false, text, null, Markers.EMPTY);
+    }
+    public static Xml.Comment createXmlComment(String text) {
+        return new Xml.Comment(UUID.randomUUID(), null, Markers.EMPTY, text);
+    }
+
+    //--------------- typeCast helper --------------------------------
+
+    public static J createTypeCast(Object type, Expression arg) {
+       return new J.TypeCast(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                RecipesUtil.createParentheses(type),
+                arg);
+    }
+
+    // -------------------- other helper methods
+
+    public static <T> J.ControlParentheses createParentheses(T t) {
+        return new J.ControlParentheses(
+                Tree.randomId(),
+                Space.EMPTY,
+                Markers.EMPTY,
+                padRight(t));
+    }
+
+    public static J.Identifier createIdentifier(Space prefix, String name, String type) {
+       return new J.Identifier(randomId(), prefix, Markers.EMPTY, name,
+                JavaType.ShallowClass.build(type), null);
+    }
+
+    private static <T> JRightPadded<T> padRight(T tree) {
+        return new JRightPadded<>(tree, Space.EMPTY, Markers.EMPTY);
+    }
+
+    public static String getProperty(Cursor cursor) {
+        StringBuilder asProperty = new StringBuilder();
+        Iterator<Object> path = cursor.getPath();
+        int i = 0;
+        while (path.hasNext()) {
+            Object next = path.next();
+            if (next instanceof Yaml.Mapping.Entry) {
+                Yaml.Mapping.Entry entry = (Yaml.Mapping.Entry) next;
+                if (i++ > 0) {
+                    asProperty.insert(0, '.');
+                }
+                asProperty.insert(0, entry.getKey().getValue());
+            }
+            if (next instanceof Xml.Tag) {
+                Xml.Tag t = (Xml.Tag) next;
+                if (i++ > 0) {
+                    asProperty.insert(0, '/');
+                }
+                asProperty.insert(0, t.getName());
+            }
+        }
+        return asProperty.toString();
+    }
+
+    public enum Category {
+        DATAMINING("datamining"),
+        AI("ai"),
+        API("api"),
+        AZURE("azure"),
+        BATCH("batch"),
+        BIGDATA("bigdata"),
+        BITCOIN("bitcoin"),
+        BLOCKCHAIN("blockchain"),
+        CACHE("cache"),
+        CHAT("chat"),
+        CLOUD("cloud"),
+        CLUSTERING("clustering"),
+        CMS("cms"),
+        COMPUTE("compute"),
+        COMPUTING("computing"),
+        CONTAINER("container"),
+        CORE("core"),
+        CRM("crm"),
+        DATA("data"),
+        DATABASE("database"),
+        DATAGRID("datagrid"),
+        DEEPLEARNING("deeplearning"),
+        DEPLOYMENT("deployment"),
+        DOCUMENT("document"),
+        ENDPOINT("endpoint"),
+        ENGINE("engine"),
+        EVENTBUS("eventbus"),
+        FILE("file"),
+        HADOOP("hadoop"),
+        HCM("hcm"),
+        HL7("hl7"),
+        HTTP("http"),
+        IOT("iot"),
+        IPFS("ipfs"),
+        JAVA("java"),
+        LDAP("ldap"),
+        LEDGER("ledger"),
+        LOCATION("location"),
+        LOG("log"),
+        MAIL("mail"),
+        MANAGEMENT("management"),
+        MESSAGING("messaging"),
+        MLLP("mllp"),
+        MOBILE("mobile"),
+        MONITORING("monitoring"),
+        NETWORKING("networking"),
+        NOSQL("nosql"),
+        OPENAPI("openapi"),
+        PAAS("paas"),
+        PAYMENT("payment"),
+        PLANNING("planning"),
+        PRINTING("printing"),
+        PROCESS("process"),
+        QUEUE("queue"),
+        REACTIVE("reactive"),
+        REPORTING("reporting"),
+        REST("rest"),
+        RPC("rpc"),
+        RSS("rss"),
+        SAP("sap"),
+        SCHEDULING("scheduling"),
+        SCRIPT("script"),
+        SEARCH("search"),
+        SECURITY("security"),
+        SERVERLESS("serverless"),
+        SHEETS("sheets"),
+        SOAP("soap"),
+        SOCIAL("social"),
+        SPRING("spring"),
+        SQL("sql"),
+        STREAMS("streams"),
+        SUPPORT("support"),
+        SWAGGER("swagger"),
+        SYSTEM("system"),
+        TCP("tcp"),
+        TESTING("testing"),
+        TRANSFORMATION("transformation"),
+        UDP("udp"),
+        VALIDATION("validation"),
+        VOIP("voip"),
+        WEBSERVICE("webservice"),
+        WEBSOCKET("websocket"),
+        WORKFLOW("workflow");
+    
+        private final String value;
+    
+        Category(final String value) {
+            this.value = value;
+        }
+    
+        /**
+         * Returns the string representation of this value
+         * 
+         * @return Returns the string representation of this value
+         */
+        public String getValue() {
+            return this.value;
+        }
+    }
+
+}

--- a/recipes/src/main/java/io/quarkus/updates/camel30/java/CamelAPIsRecipe.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/java/CamelAPIsRecipe.java
@@ -1,0 +1,342 @@
+package io.quarkus.updates.camel30.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AddImport;
+import org.openrewrite.java.ChangePackage;
+import org.openrewrite.java.ImplementInterface;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.RemoveImplements;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
+
+import io.quarkus.updates.camel30.AbstractCamelQuarkusJavaVisitor;
+import io.quarkus.updates.camel30.RecipesUtil;
+
+import java.beans.SimpleBeanInfo;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * Recipe migrating changes between Camel 3.x to 4.x, for more details see the
+ * <a href="URL#https://camel.apache.org/manual/camel-4-migration-guide.html#_api_changes" >documentation</a>.
+ */
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class CamelAPIsRecipe extends Recipe {
+
+    private static final String MATCHER_CONTEXT_GET_ENDPOINT_MAP = "org.apache.camel.CamelContext getEndpointMap()";
+    private static final String MATCHER_CONTEXT_GET_EXT = "org.apache.camel.CamelContext getExtension(java.lang.Class)";
+    private static final String MATCHER_GET_NAME_RESOLVER = "org.apache.camel.ExtendedCamelContext getComponentNameResolver()";
+    private static final String M_PRODUCER_TEMPLATE_ASYNC_CALLBACK = "org.apache.camel.ProducerTemplate asyncCallback(..)";
+    private static final String M_CONTEXT_ADAPT = "org.apache.camel.CamelContext adapt(java.lang.Class)";
+    private static final String M_CONTEXT_SET_DUMP_ROUTES = "org.apache.camel.CamelContext setDumpRoutes(java.lang.Boolean)";
+    private static final String M_CONTEXT_IS_DUMP_ROUTES = "org.apache.camel.CamelContext isDumpRoutes()";
+    private static final String M_EXCHANGE_ADAPT = "org.apache.camel.Exchange adapt(java.lang.Class)";
+    private static final String M_EXCHANGE_GET_PROPERTY = "org.apache.camel.Exchange getProperty(org.apache.camel.ExchangePropertyKey)";
+    private static final String M_EXCHANGE_REMOVE_PROPERTY = "org.apache.camel.Exchange removeProperty(org.apache.camel.ExchangePropertyKey)";
+    private static final String M_EXCHANGE_SET_PROPERTY = "org.apache.camel.Exchange setProperty(..)";
+    private static final String M_CATALOG_ARCHETYPE_AS_XML = "org.apache.camel.catalog.CamelCatalog archetypeCatalogAsXml()";
+
+    @Override
+    public String getDisplayName() {
+        return "Camel API changes";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel API migration from version 3.20 or higher to 4.0. Removal of deprecated APIs.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new AbstractCamelQuarkusJavaVisitor() {
+
+            //Cache for all methodInvocations CamelContext adapt(java.lang.Class).
+            private Map<UUID, Tree> adaptCache = new HashMap<>();
+
+            @Override
+            protected J.Import doVisitImport(J.Import _import, ExecutionContext context) {
+                J.Import im = super.doVisitImport(_import, context);
+
+                //Removed Discard and DiscardOldest from org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy.
+                if(im.isStatic() && im.getTypeName().equals("org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy")
+                        && im.getQualid() != null
+                        && ("Discard".equals(im.getQualid().getSimpleName()) || "DiscardOldest".equals(im.getQualid().getSimpleName()))) {
+                    Comment comment = RecipesUtil.createMultinlineComment(String.format("'ThreadPoolRejectedPolicy.%s' has been removed, consider using 'ThreadPoolRejectedPolicy.Abort'.", im.getQualid().getSimpleName()));
+                    im = im.withComments(Collections.singletonList(comment));
+
+                }
+                //Removed org.apache.camel.builder.SimpleBuilder.
+                // Was mostly used internally in Camel with the Java DSL in some situations.
+                else if("org.apache.camel.builder.SimpleBuilder".equals(im.getTypeName())) {
+                    Comment comment = RecipesUtil.createMultinlineComment(String.format("'%s' has been removed, (class was used internally).", SimpleBeanInfo.class.getCanonicalName()));
+                    im = im.withComments(Collections.singletonList(comment));
+
+                }
+
+                //Move the following class from org.apache.camel.api.management.mbean.BacklogTracerEventMessage in camel-management-api JAR to org.apache.camel.spi.BacklogTracerEventMessage in camel-api JAR.
+                //
+                // BacklogTracerEventMessage moved from `org.apache.camel.api.management.mbean.BacklogTracerEventMessage`
+                // to  `org.apache.camel.spi.BacklogTracerEventMessage`
+                //TODO should be refactorable to yaml recipe simply, but ChangePackage does not work from yaml declaration
+                doAfterVisit(
+                        new ChangePackage("org.apache.camel.api.management.mbean.BacklogTracerEventMessage",
+                        "org.apache.camel.spi.BacklogTracerEventMessage", null));
+
+                return im;
+            }
+
+            @Override
+            protected J.ClassDeclaration doVisitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext context) {
+                J.ClassDeclaration cd = super.doVisitClassDeclaration(classDecl, context);
+
+                //Removed org.apache.camel.spi.OnCamelContextStart. Use org.apache.camel.spi.OnCamelContextStarting instead.
+                if(cd.getImplements() != null && cd.getImplements().stream()
+                        .anyMatch(f -> TypeUtils.isOfClassType(f.getType(), "org.apache.camel.spi.OnCamelContextStart"))) {
+
+                    doAfterVisit(new ImplementInterface<ExecutionContext>(cd, "org.apache.camel.spi.OnCamelContextStarting"));
+                    doAfterVisit(new RemoveImplements("org.apache.camel.spi.OnCamelContextStart", null));
+
+                } //Removed org.apache.camel.spi.OnCamelContextStop. Use org.apache.camel.spi.OnCamelContextStopping instead.
+                else if(cd.getImplements() != null && cd.getImplements().stream()
+                        .anyMatch(f -> TypeUtils.isOfClassType(f.getType(), "org.apache.camel.spi.OnCamelContextStop"))) {
+
+                    doAfterVisit(new ImplementInterface<ExecutionContext>(cd, "org.apache.camel.spi.OnCamelContextStopping"));
+                    doAfterVisit(new RemoveImplements("org.apache.camel.spi.OnCamelContextStop", null));
+
+                }
+                return cd;
+            }
+
+            @Override
+            protected J.FieldAccess doVisitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext context) {
+                J.FieldAccess fa =  super.doVisitFieldAccess(fieldAccess, context);
+                //The org.apache.camel.ExchangePattern has removed InOptionalOut.
+                if("InOptionalOut".equals(fieldAccess.getSimpleName()) && fa.getType() != null && fa.getType().isAssignableFrom(Pattern.compile("org.apache.camel.ExchangePattern"))) {
+                    return fa.withName(new J.Identifier(UUID.randomUUID(), fa.getPrefix(), Markers.EMPTY, "/* " + fa.getSimpleName() + " has been removed */", fa.getType(), null));
+                }
+
+                else if(("Discard".equals(fa.getSimpleName()) || "DiscardOldest".equals(fa.getSimpleName()))
+                        && fa.getType() != null && fa.getType().isAssignableFrom(Pattern.compile("org.apache.camel.util.concurrent.ThreadPoolRejectedPolicy"))
+                ) {
+                    Comment comment = RecipesUtil.createMultinlineComment(String.format("'ThreadPoolRejectedPolicy.%s' has been removed, consider using 'ThreadPoolRejectedPolicy.Abort'.", fa.getSimpleName()));
+                    fa = fa.withComments(Collections.singletonList(comment));
+
+                }
+
+
+                return fa;
+            }
+
+            @Override
+            protected J.MethodDeclaration doVisitMethodDeclaration(J.MethodDeclaration method, ExecutionContext context) {
+                J.MethodDeclaration md = super.doVisitMethodDeclaration(method, context);
+
+                //Method 'configure' was removed from `org.apache.camel.main.MainListener`, consider using 'beforeConfigure' or 'afterConfigure'.
+                if("configure".equals(md.getSimpleName())
+                        && md.getReturnTypeExpression().getType().equals(JavaType.Primitive.Void)
+                        && getImplementsList().stream().anyMatch(jt -> "org.apache.camel.main.MainListener".equals(jt.toString()))
+                        && !md.getParameters().isEmpty()
+                        && md.getParameters().size() == 1
+                        && md.getParameters().get(0) instanceof J.VariableDeclarations
+                        && ((J.VariableDeclarations)md.getParameters().get(0)).getType().isAssignableFrom(Pattern.compile("org.apache.camel.CamelContext"))) {
+                    Comment comment = RecipesUtil.createMultinlineComment(String.format(" Method '%s' was removed from `%s`, consider using 'beforeConfigure' or 'afterConfigure'. ", md.getSimpleName(), "org.apache.camel.main.MainListener"));
+                    md = md.withComments(Collections.singletonList(comment));
+                }
+
+                return md;
+            }
+
+            @Override
+            protected J.Annotation doVisitAnnotation(J.Annotation annotation, ExecutionContext context) {
+                J.Annotation a = super.doVisitAnnotation(annotation, context);
+
+                //Removed @FallbackConverter as you should use @Converter(fallback = true) instead.
+                if (a.getType().toString().equals("org.apache.camel.FallbackConverter")) {
+                    maybeAddImport("org.apache.camel.Converter", null, false);
+                    maybeRemoveImport("org.apache.camel.FallbackConverter");
+
+                    return RecipesUtil.createAnnotation(annotation, "Converter", null, "fallback = true");
+                }
+                //Removed uri attribute on @EndpointInject, @Produce, and @Consume as you should use value (default) instead.
+                //For example @Produce(uri = "kafka:cheese") should be changed to @Produce("kafka:cheese")
+                else if (a.getType().toString().equals("org.apache.camel.EndpointInject")) {
+                    Optional<String> originalValue = RecipesUtil.getValueOfArgs(a.getArguments(), "uri");
+                    if(originalValue.isPresent()) {
+                        return RecipesUtil.createAnnotation(annotation, "EndpointInject", s -> s.startsWith("uri="), originalValue.get());
+                    }
+                }
+                //Removed uri attribute on @EndpointInject, @Produce, and @Consume as you should use value (default) instead.
+                //For example @Produce(uri = "kafka:cheese") should be changed to @Produce("kafka:cheese")
+                else if (a.getType().toString().equals("org.apache.camel.Produce")) {
+                    Optional<String> originalValue = RecipesUtil.getValueOfArgs(a.getArguments(), "uri");
+                    if(originalValue.isPresent()) {
+                        return RecipesUtil.createAnnotation(annotation, "Produce", s -> s.startsWith("uri="), originalValue.get());
+                    }
+                }
+                //Removed uri attribute on @EndpointInject, @Produce, and @Consume as you should use value (default) instead.
+                //For example @Produce(uri = "kafka:cheese") should be changed to @Produce("kafka:cheese")
+                else if (a.getType().toString().equals("org.apache.camel.Consume")) {
+                    Optional<String> originalValue = RecipesUtil.getValueOfArgs(a.getArguments(), "uri");
+                    if(originalValue.isPresent()) {
+                        return RecipesUtil.createAnnotation(annotation, "Consume", s -> s.startsWith("uri="), originalValue.get());
+                    }
+                }
+                // Removed label on @UriEndpoint as you should use category instead.
+                else if (a.getType().toString().equals("org.apache.camel.spi.UriEndpoint")) {
+
+                    Optional<String> originalValue = RecipesUtil.getValueOfArgs(a.getArguments(), "label");
+                    if(originalValue.isPresent()) {
+                        maybeAddImport("org.apache.camel.Category", null, false);
+
+                        String newValue;
+                        try {
+                            newValue = RecipesUtil.Category.valueOf(originalValue.get().toUpperCase().replaceAll("\"", "")).getValue();
+                        } catch(IllegalArgumentException e) {
+                            newValue = originalValue.get() + "/*unknown_value*/";
+                        }
+
+                        return RecipesUtil.createAnnotation(annotation, "UriEndpoint", s -> s.startsWith("label="), "category = {Category." + newValue + "}");
+                    }
+                }
+
+                return a;
+            }
+
+            @Override
+            protected J.MethodInvocation doVisitMethodInvocation(J.MethodInvocation method, ExecutionContext context) {
+                J.MethodInvocation mi = super.doVisitMethodInvocation(method, context);
+
+                //if adapt method invocation is used as a select for another method invocation, it is replaced
+                if(mi.getSelect() != null && adaptCache.containsKey(mi.getSelect().getId())) {
+                    getCursor().putMessage("adapt_cast", mi.getSelect().getId());
+                } else
+                // context.getExtension(ExtendedCamelContext.class).getComponentNameResolver() -> PluginHelper.getComponentNameResolver(context)
+                if (getMethodMatcher(MATCHER_CONTEXT_GET_ENDPOINT_MAP).matches(mi)) {
+                    mi = mi.withName(new J.Identifier(UUID.randomUUID(), mi.getPrefix(), Markers.EMPTY,
+                            "/* " + mi.getSimpleName() + " has been removed, consider getEndpointRegistry() instead */", mi.getType(), null));
+                }
+                // ProducerTemplate.asyncCallback() has been replaced by 'asyncSend(') or 'asyncRequest()'
+                else if(getMethodMatcher(M_PRODUCER_TEMPLATE_ASYNC_CALLBACK).matches(mi)) {
+                    Comment comment = RecipesUtil.createMultinlineComment(String.format(" Method '%s()' has been replaced by 'asyncSend()' or 'asyncRequest()'.", mi.getSimpleName()));
+                    mi = mi.withComments(Collections.singletonList(comment));
+                }
+                //context.adapt(ModelCamelContext.class) -> ((ModelCamelContext) context)
+                else if (getMethodMatcher(M_CONTEXT_ADAPT).matches(mi)) {
+                    if (mi.getType().isAssignableFrom(Pattern.compile("org.apache.camel.model.ModelCamelContext"))) {
+                        J.Identifier type = RecipesUtil.createIdentifier(mi.getPrefix(), "ModelCamelContext", "java.lang.Object");
+                        J.ControlParentheses cp  =  RecipesUtil.createParentheses(RecipesUtil.createTypeCast(type, mi.getSelect()));
+                        //put the type cast into cache in case it is replaced lately
+                        mi = mi.withComments(Collections.singletonList(RecipesUtil.createMultinlineComment("Method 'adapt' was removed.")));
+                        adaptCache.put(method.getId(), cp);
+                    } else if (mi.getType().isAssignableFrom(Pattern.compile("org.apache.camel.ExtendedCamelContext"))) {
+                        mi = mi.withName(mi.getName().withSimpleName("getCamelContextExtension")).withArguments(Collections.emptyList());
+                        maybeRemoveImport("org.apache.camel.ExtendedCamelContext");
+                    }
+                }
+                //exchange.adapt(ExtendedExchange.class) -> exchange.getExchangeExtension()
+                else if (getMethodMatcher(M_EXCHANGE_ADAPT).matches(mi)
+                        && mi.getType().isAssignableFrom(Pattern.compile("org.apache.camel.ExtendedExchange"))) {
+                    mi = mi.withName(mi.getName().withSimpleName("getExchangeExtension")).withArguments(Collections.emptyList());
+                    maybeRemoveImport("org.apache.camel.ExtendedExchange");
+                }
+                //newExchange.getProperty(ExchangePropertyKey.FAILURE_HANDLED) -> newExchange.getExchangeExtension().isFailureHandled()
+                else if(getMethodMatcher(M_EXCHANGE_GET_PROPERTY).matches(mi)
+                        && mi.getArguments().get(0).toString().endsWith("FAILURE_HANDLED")) {
+                    mi = mi.withName(mi.getName().withSimpleName("getExchangeExtension().isFailureHandled")).withArguments(Collections.emptyList());
+                    maybeRemoveImport("org.apache.camel.ExchangePropertyKey");
+                }
+                //exchange.removeProperty(ExchangePropertyKey.FAILURE_HANDLED); -> exchange.getExchangeExtension().setFailureHandled(false);
+                else if(getMethodMatcher(M_EXCHANGE_REMOVE_PROPERTY).matches(mi)
+                        && mi.getArguments().get(0).toString().endsWith("FAILURE_HANDLED")) {
+                    mi = mi.withName(mi.getName().withSimpleName("getExchangeExtension().setFailureHandled")).withArguments(Collections.singletonList(RecipesUtil.createIdentifier(Space.EMPTY, "false", "java.lang.Boolean")));
+                    maybeRemoveImport("org.apache.camel.ExchangePropertyKey");
+                }
+                //exchange.setProperty(ExchangePropertyKey.FAILURE_HANDLED, failureHandled); -> exchange.getExchangeExtension().setFailureHandled(failureHandled);
+                else if(getMethodMatcher(M_EXCHANGE_SET_PROPERTY).matches(mi)
+                        && mi.getArguments().get(0).toString().endsWith("FAILURE_HANDLED")) {
+                    mi = mi.withName(mi.getName()
+                                    .withSimpleName("getExchangeExtension().setFailureHandled"))
+                            .withArguments(Collections.singletonList(mi.getArguments().get(1).withPrefix(Space.EMPTY)));
+                    maybeRemoveImport("org.apache.camel.ExchangePropertyKey");
+                }
+                //'org.apache.camel.catalogCamelCatalog.archetypeCatalogAsXml()` has been removed
+                else if(getMethodMatcher(M_CATALOG_ARCHETYPE_AS_XML).matches(mi)) {
+                    mi = mi.withComments(Collections.singletonList(RecipesUtil.createMultinlineComment(" Method '" + mi.getSimpleName() + "' has been removed. ")));
+                }
+                //context().setDumpRoutes(true); -> context().setDumpRoutes("xml");(or "yaml")
+                else if(getMethodMatcher(M_CONTEXT_SET_DUMP_ROUTES).matches(mi)) {
+                    mi = mi.withComments(Collections.singletonList(RecipesUtil.createMultinlineComment(" Method '" + mi.getSimpleName() + "' accepts String parameter ('xml' or 'yaml' or 'false'). ")));
+                }
+                //Boolean isDumpRoutes(); -> getDumpRoutes(); with returned type String
+                else if(getMethodMatcher(M_CONTEXT_IS_DUMP_ROUTES).matches(mi)) {
+                    mi = mi.withName(mi.getName().withSimpleName("getDumpRoutes")).withComments(Collections.singletonList(RecipesUtil.createMultinlineComment(" Method 'getDumpRoutes' returns String value ('xml' or 'yaml' or 'false'). ")));
+                }
+                // context.getExtension(ExtendedCamelContext.class).getComponentNameResolver() -> PluginHelper.getComponentNameResolver(context)
+                else if (getMethodMatcher(MATCHER_GET_NAME_RESOLVER).matches(mi)) {
+                    if (mi.getSelect() instanceof J.MethodInvocation && getMethodMatcher(MATCHER_CONTEXT_GET_EXT).matches(((J.MethodInvocation) mi.getSelect()).getMethodType())) {
+                        J.MethodInvocation innerInvocation = (J.MethodInvocation) mi.getSelect();
+                        mi = mi.withTemplate(JavaTemplate.builder(() -> getCursor().getParentOrThrow(), "PluginHelper.getComponentNameResolver(#{any(org.apache.camel.CamelContext)})")
+                                        .build(),
+                                mi.getCoordinates().replace(), innerInvocation.getSelect());
+                        doAfterVisit(new AddImport<>("org.apache.camel.support.PluginHelper", null, false));
+                    }
+                }
+                // (CamelRuntimeCatalog) context.getExtension(RuntimeCamelCatalog.class) -> context.getCamelContextExtension().getContextPlugin(RuntimeCamelCatalog.class);
+                else if (getMethodMatcher(MATCHER_CONTEXT_GET_EXT).matches(mi)) {
+
+                    mi = mi.withName(mi.getName().withSimpleName("getCamelContextExtension().getContextPlugin"))
+                            .withMethodType(mi.getMethodType());
+                    //remove type cast before expression
+                    if(getCursor().getParent().getValue() instanceof J.TypeCast && ((J.TypeCast)getCursor().getParent().getValue()).getType().equals(mi.getType())) {
+                        getCursor().getParent().putMessage("remove_type_cast", mi);
+                    }
+
+                }
+                return mi;
+            }
+
+            @Override
+            public @Nullable J postVisit(J tree, ExecutionContext context) {
+                J j =  super.postVisit(tree, context);
+
+                UUID adaptCast = getCursor().getMessage("adapt_cast");
+
+                if(adaptCast != null) {
+                    J.MethodInvocation mi = (J.MethodInvocation)j;
+                    J.ControlParentheses cp = (J.ControlParentheses) adaptCache.get(adaptCast);
+
+                    J.MethodInvocation m = mi.withSelect(cp);
+                    return m;
+                }
+
+                J removeTypeCast = getCursor().getMessage("remove_type_cast");
+
+                if(removeTypeCast != null) {
+                    return removeTypeCast;
+                }
+
+                return j;
+            }
+
+        };
+    }
+
+}
+

--- a/recipes/src/main/java/io/quarkus/updates/camel30/java/CamelBeanRecipe.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/java/CamelBeanRecipe.java
@@ -1,0 +1,143 @@
+package io.quarkus.updates.camel30.java;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.ChangeLiteral;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import io.quarkus.updates.camel30.AbstractCamelQuarkusJavaVisitor;
+
+public class CamelBeanRecipe extends Recipe {
+
+    private final String primitive[] = new String[] { "byte", "short", "int", "float", "double", "long", "char",
+            "String" };
+
+    @Override
+    public String getDisplayName() {
+        return "Camel bean recipe";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Camel bean recipe.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AbstractCamelQuarkusJavaVisitor() {
+
+            @Override
+            protected J.MethodInvocation doVisitMethodInvocation(J.MethodInvocation method, ExecutionContext context) {
+                J.MethodInvocation mi = super.doVisitMethodInvocation(method, context);
+                Pattern findMethodPattern = Pattern.compile("method=.*");
+
+                if (mi.getSimpleName().equals("to")) {
+                    List<Expression> arguments = method.getArguments();
+
+                    for (int i = 0; i < arguments.size(); i++) {
+                        Expression argument = arguments.get(i);
+                        if (argument instanceof J.Literal
+                                && ((J.Literal) argument).getType().getClassName().equals("java.lang.String")
+                                && findMethodPattern
+                                        .matcher((String) (((J.Literal) method.getArguments().get(i)).getValue()))
+                                        .find()) {
+
+                            String uriWithMethod = (String) (((J.Literal) method.getArguments().get(i)).getValue());
+
+                            String uriWithoutMethod = uriWithMethod.split("=")[0];
+
+                            String methodNameAndArgs = uriWithMethod.split("=")[1];
+                            
+                            //method without any args, we can simply return the mi in that case.
+                            if(!methodNameAndArgs.contains("(") && !methodNameAndArgs.contains(")")) {
+                                return mi;
+                            }
+
+                            String methodName = extractMethodName(methodNameAndArgs);
+
+                            String actualArgs = methodNameAndArgs.substring(
+                                    methodNameAndArgs.indexOf("(") + 1,
+                                    methodNameAndArgs.indexOf(")"));
+
+                            String updatedArg = uriWithoutMethod + "=" + methodName + "(" + updateMethodArgument(actualArgs)
+                                    + ")";
+
+                            doAfterVisit(new ChangeLiteral<>(argument, p -> updatedArg));
+
+                            return mi;
+
+                        }
+
+                    }
+
+                }
+
+                return mi;
+            }
+
+        };
+
+    };
+
+    private String extractMethodName(String methodCallString) {
+        // Regular expression to match the method call pattern
+        Pattern pattern = Pattern.compile("^([a-zA-Z_$][a-zA-Z0-9_$]*)\\(.+\\)$");
+        Matcher matcher = pattern.matcher(methodCallString);
+
+        // Check if the string matches the method call pattern
+        if (matcher.matches()) {
+            // Extract the method name from the matched group
+            String methodName = matcher.group(1);
+            return methodName;
+        } else {
+            // Return null if the string doesn't match the method call pattern
+            return null;
+        }
+    }
+
+    private String updateMethodArgument(String argument) {
+
+        Pattern identifierPattern = Pattern.compile("^[a-zA-Z_$][a-zA-Z0-9_$]*$");
+        Pattern fullyQualifiedPattern = Pattern
+                .compile("^([a-zA-Z_$][a-zA-Z0-9_$]*\\.)*[a-zA-Z_$][a-zA-Z0-9_$]*$");
+
+        String updatedArgs = Arrays.asList(argument.split(",")).stream().map(arg -> {
+            if (arg.endsWith(".class")) {
+                return arg;
+            }
+
+            if (Arrays.asList(primitive).contains(arg.trim())) {
+                return arg + ".class";
+            }
+
+            Matcher fullyQualifiedMatcher = fullyQualifiedPattern.matcher(arg);
+            if (!fullyQualifiedMatcher.matches()) {
+                return arg;
+            }
+
+            String[] parts = arg.split("\\.");
+
+            for (String part : parts) {
+                Matcher identifierMatcher = identifierPattern.matcher(part);
+                if (!identifierMatcher.matches()) {
+                    return arg;
+                }
+            }
+
+            return arg + ".class";
+
+        }).collect(Collectors.joining(","));
+
+        return updatedArgs;
+
+    }
+
+}

--- a/recipes/src/main/java/io/quarkus/updates/camel30/java/CamelEIPRecipe.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/java/CamelEIPRecipe.java
@@ -1,0 +1,43 @@
+package io.quarkus.updates.camel30.java;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AddImport;
+import org.openrewrite.java.tree.J;
+
+import io.quarkus.updates.camel30.AbstractCamelQuarkusJavaVisitor;
+
+public class CamelEIPRecipe extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Replaces removed method camel EIP";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The InOnly and InOut EIPs have been removed. Instead, use 'SetExchangePattern' or 'To' where you can specify the exchange pattern to use.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AbstractCamelQuarkusJavaVisitor() {
+
+            @Override
+            protected J.MethodInvocation doVisitMethodInvocation(J.MethodInvocation method, ExecutionContext context) {
+                J.MethodInvocation mi =  super.doVisitMethodInvocation(method, context);
+
+                if (mi.getSimpleName().equals("inOut") || mi.getSimpleName().equals("inOnly")) {
+                    String name = mi.getSimpleName().substring(0, 1).toUpperCase() + mi.getSimpleName().substring(1);
+                    mi = mi.withName(mi.getName().withSimpleName("setExchangePattern(ExchangePattern."+name+").to"));
+                    doAfterVisit(new AddImport<>("org.apache.camel.ExchangePattern", null, false));
+                }
+                return mi;
+            }
+
+        };
+
+    };
+
+}

--- a/recipes/src/main/java/io/quarkus/updates/camel30/java/CamelHttpRecipe.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/java/CamelHttpRecipe.java
@@ -1,0 +1,89 @@
+package io.quarkus.updates.camel30.java;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.ChangePackage;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+
+import io.quarkus.updates.camel30.AbstractCamelQuarkusJavaVisitor;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class CamelHttpRecipe extends Recipe {
+
+    private static final String SET_CREDENTIALS = "org.apache.http.impl.client.BasicCredentialsProvider setCredentials(..)";
+    private static final String SCOPE_ANY = "AuthScope.ANY";
+
+    @Override
+    public String getDisplayName() {
+        return "Camel Http Extension changes";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Camel Http Extension changes.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new AbstractCamelQuarkusJavaVisitor() {
+            @Override
+            protected J.Import doVisitImport(J.Import _import, ExecutionContext context) {
+                doAfterVisit( new ChangePackage("org.apache.http.HttpHost", "org.apache.hc.core5.http.HttpHost", null));
+                doAfterVisit( new ChangePackage("org.apache.http.client.protocol.HttpClientContext", "org.apache.hc.client5.http.protocol.HttpClientContext", null));
+                doAfterVisit( new ChangePackage("org.apache.http.impl.client", "org.apache.hc.client5.http.impl.auth", null));
+                doAfterVisit( new ChangePackage("org.apache.http.protocol.HttpContext", "org.apache.hc.core5.http.protocol.HttpContext", null));
+                doAfterVisit( new ChangePackage("org.apache.http", "org.apache.hc.client5.http", null));
+
+                return super.doVisitImport(_import, context);
+            }
+
+            @Override
+            protected J.FieldAccess doVisitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext context) {
+                J.FieldAccess f = super.doVisitFieldAccess(fieldAccess, context);
+
+                //The component has been upgraded to use Apache HttpComponents v5
+                //AuthScope.ANY -> new AuthScope(null, -1)
+                if("ANY".equals(f.getSimpleName()) && "org.apache.http.auth.AuthScope".equals(f.getType().toString())) {
+                    JavaTemplate.Builder templateBuilder = JavaTemplate.builder(this::getCursor, "new AuthScope(null, -1)")
+                            .imports("org.apache.hc.client5.http.auth.AuthScope");
+                    J.NewClass nc = f.withTemplate(
+                                        templateBuilder.build(),
+                                        f.getCoordinates().replace())
+                                     .withPrefix(f.getPrefix()
+                    );
+                    getCursor().putMessage("authScopeNewClass", nc);
+                }
+                return f;
+            }
+
+            @Override
+            public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext context) {
+                return super.visitNewClass(newClass, context);
+            }
+
+
+            @Override
+            public @Nullable J postVisit(J tree, ExecutionContext context) {
+                J j = super.postVisit(tree, context);
+
+                //use a new class instead of original element
+                J.NewClass newClass = getCursor().getMessage("authScopeNewClass");
+                if(newClass != null) {
+                    return newClass;
+                }
+
+                return j;
+            }
+
+        };
+    }
+
+}

--- a/recipes/src/main/java/io/quarkus/updates/camel30/xml/XmlDslRecipe.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/xml/XmlDslRecipe.java
@@ -1,0 +1,82 @@
+package io.quarkus.updates.camel30.xml;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.XmlIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+/**
+ * <p>
+ * <a:href link="https://camel.apache.org/manual/camel-4-migration-guide.html#_xml_dsl" >Camel Migration guide</a:href>
+ * </p>
+ * The <description> to set a description on a route or node, has been changed from an element to an attribute.
+ *
+ * Before:
+ * <pre>
+ * &lt;route id=&quot;myRoute&quot;&gt;
+ *   &lt;description&gt;Something that this route do&lt;/description&gt;
+ *   &lt;from uri=&quot;kafka:cheese&quot;/&gt;
+ *   ...
+ * &lt;/route&gt;
+ * </pre>
+ * After:
+ * <pre>
+ * &lt;route id=&quot;myRoute&quot; description=&quot;Something that this route do&quot;&gt;
+ *   &lt;from uri=&quot;kafka:cheese&quot;/&gt;
+ *   ...
+ * &lt;/route&gt;
+ * </pre>
+ */
+public class XmlDslRecipe extends Recipe {
+
+    private static final XPathMatcher ROUTE_DESCRIPTION_XPATH_MATCHER = new XPathMatcher("/routes/route/description");
+    private static final XPathMatcher ROUTE_XPATH_MATCHER = new XPathMatcher("/routes/route");
+
+    @Override
+    public String getDisplayName() {
+        return "Camel XMl DSL changes";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel XML DSL migration from version 3.20 or higher to 4.0.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new XmlIsoVisitor<>() {
+
+            @Override
+            public Xml.Tag visitTag(final Xml.Tag tag, final ExecutionContext ctx) {
+                Xml.Tag t = super.visitTag(tag, ctx);
+
+
+                if (ROUTE_XPATH_MATCHER.matches(getCursor())) {
+                    String d = ctx.pollMessage("description");
+                    if(d != null) {
+                        return t.withAttributes(ListUtils.concat(t.getAttributes(), autoFormat(new Xml.Attribute(Tree.randomId(), "", Markers.EMPTY,
+                                new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, "description"),
+                                "",
+                                autoFormat(new Xml.Attribute.Value(Tree.randomId(), "", Markers.EMPTY,
+                                        Xml.Attribute.Value.Quote.Double,
+                                         d), ctx)), ctx)));
+                    }
+                }
+                if (ROUTE_DESCRIPTION_XPATH_MATCHER.matches(getCursor())) {
+                    //save description into context for parent
+                    t.getValue().ifPresent(s -> ctx.putMessage("description", s));
+                    //skip tag
+                    return null;
+
+                }
+
+                return t;
+            }
+        };
+    }
+}

--- a/recipes/src/main/java/io/quarkus/updates/camel30/yaml/CamelQuarkusYamlRouteConfigurationSequenceRecipe.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/yaml/CamelQuarkusYamlRouteConfigurationSequenceRecipe.java
@@ -1,0 +1,108 @@
+package io.quarkus.updates.camel30.yaml;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.format.IndentsVisitor;
+import org.openrewrite.yaml.style.IndentsStyle;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.openrewrite.Tree.randomId;
+
+/**
+ * Camel API changes requires several changes in YAML route definition.
+ * Route-configuration children sequence is replaced with  mappingEntry (with special migration of "on-exception")
+ */
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class CamelQuarkusYamlRouteConfigurationSequenceRecipe extends Recipe {
+
+    private static JsonPathMatcher MATCHER_ROUTE_CONFIGURATION = new JsonPathMatcher("$.route-configuration");
+    private static JsonPathMatcher MATCHER_ROUTE_CONFIGURATION_ON_EXCEPTION = new JsonPathMatcher("$.route-configuration.on-exception");
+
+    @Override
+    public String getDisplayName() {
+        return "Camel Yaml changes regardinhg route-configuration children";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Camel YAML changes. route-configuration children sequence is replaced with  mappingEntry (with special migration of \"on-exception\").";
+    }
+
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new CamelQuarkusYamlVisitor() {
+
+            private Yaml.Sequence sequenceToReplace;
+            private boolean indentRegistered = false;
+
+            @Override
+            void clearLocalCache() {
+                sequenceToReplace = null;
+            }
+
+            @Override
+            public Yaml.Sequence visitSequence(Yaml.Sequence sequence, ExecutionContext context) {
+                Yaml.Sequence s = super.visitSequence(sequence, context);
+
+                //if there is a sequence in a route-configuration, it has to be replaced with mapping
+                if (new JsonPathMatcher("$.route-configuration").matches(getCursor().getParent())) {
+                    this.sequenceToReplace = s;
+                }
+                return s;
+            }
+
+            @Override
+            public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext context) {
+                Yaml.Mapping.Entry e = super.visitMappingEntry(entry, context);
+
+                //if current mapping contains an entry with sequence belonging to route-configuration, remove the sequence
+                if (e.getValue() == sequenceToReplace) {
+                    List<Yaml.Mapping.Entry> entries = new ArrayList<>();
+                    for (Yaml.Sequence.Entry sEntry : sequenceToReplace.getEntries()) {
+
+                        if (sEntry.getBlock() instanceof Yaml.Mapping) {
+                            ((Yaml.Mapping) sEntry.getBlock()).getEntries().forEach(y -> {
+                                //if entry is on-exception from the route-configuration sequence, it has to be handled differently
+                                if ("on-exception".equals(y.getKey().getValue())) {
+                                    Yaml.Sequence newSequence = sequenceToReplace.copyPaste();
+                                    //keep only on-exception item
+                                    List<Yaml.Sequence.Entry> filteredEntries = newSequence.getEntries().stream()
+                                            .filter(se -> ((Yaml.Mapping) se.getBlock()).getEntries().stream()
+                                                    .filter(me -> "on-exception".equals(me.getKey().getValue())).findFirst().isPresent())
+                                            .collect(Collectors.toList());
+
+                                    entries.add(y.withValue(newSequence.withEntries(filteredEntries)).withPrefix("\n"));
+                                } else {
+                                    entries.add(y.withPrefix("\n"));
+                                }
+                            });
+                        }
+                    }
+                    Yaml.Mapping.Entry resultr = e.withValue(new Yaml.Mapping(randomId(), sequenceToReplace.getMarkers(), sequenceToReplace.getOpeningBracketPrefix(), entries, null, null));
+
+                    if(!indentRegistered) {
+                        indentRegistered = true;
+                        //TODO might probably change indent in original file, may this happen?
+                        doAfterVisit(new IndentsVisitor(new IndentsStyle(2), null));
+                    }
+
+                    return resultr;
+                }
+                return e;
+            }
+        };
+    }
+
+}
+

--- a/recipes/src/main/java/io/quarkus/updates/camel30/yaml/CamelQuarkusYamlStepsInFromRecipe.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/yaml/CamelQuarkusYamlStepsInFromRecipe.java
@@ -1,0 +1,122 @@
+package io.quarkus.updates.camel30.yaml;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.format.IndentsVisitor;
+import org.openrewrite.yaml.style.IndentsStyle;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fixes following yaml change.
+ *
+ * The backwards compatible mode Camel 3.14 or older, which allowed to have steps as child to route has been removed.
+ *
+ * The old syntax:
+ *
+ * <pre>
+ * - route:
+ *     from:
+ *       uri: "direct:info"
+ *     steps:
+ *     - log: "message"
+ * </pre>
+ * should be changed to:
+ * <pre>
+ * - route:
+ *     from:
+ *       uri: "direct:info"
+ *       steps:
+ *       - log: "message"
+ * </pre>
+ */
+@EqualsAndHashCode(callSuper = true)
+@Value
+public class CamelQuarkusYamlStepsInFromRecipe extends Recipe {
+
+    private  static String[] PATHS_TO_PRE_CHECK = new String[] {"route.from"};
+    private static JsonPathMatcher MATCHER_WITHOUT_ROUTE = new JsonPathMatcher("$.steps");
+    private static JsonPathMatcher MATCHER_WITH_ROUTE = new JsonPathMatcher("$.route.steps");
+
+
+    @Override
+    public String getDisplayName() {
+        return "Camel Yaml steps not allowed as route child";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The YAML DSL backwards compatible mode in Camel 3.14 or older, which allowed 'steps' to be defined as a child of 'route' has been removed.";
+    }
+
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+            return new YamlIsoVisitor<>() {
+
+                //both variables has to be set to null, to mark the migration done
+                Yaml.Mapping from = null;
+                Yaml.Mapping.Entry steps = null;
+
+                @Override
+                public Yaml.Mapping.Entry visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext context) {
+                    Yaml.Mapping.Entry e = super.visitMappingEntry(entry, context);
+
+                    if(steps == null && (MATCHER_WITH_ROUTE.matches(getCursor()) || MATCHER_WITHOUT_ROUTE.matches(getCursor()))) {
+                        steps = e;
+                        if(from != null) {
+                            moveSteps();
+                        }
+                        return null;
+                    }
+                    return e;
+
+                }
+
+                @Override
+                public Yaml.Mapping visitMapping(Yaml.Mapping mapping, ExecutionContext context) {
+                    Yaml.Mapping m =  super.visitMapping(mapping, context);
+
+                    String prop = YamlRecipesUtil.getProperty(getCursor());
+                    if(("route.from".equals(prop) || "from".equals(prop)) && from == null) {
+                        from = m;
+                        if(steps != null) {
+                            moveSteps();
+                        }
+                    }
+
+                    return m;
+                }
+
+                private void moveSteps() {
+                    doAfterVisit(new YamlIsoVisitor<ExecutionContext>()  {
+
+                        @Override
+                        public Yaml.Mapping visitMapping(Yaml.Mapping mapping, ExecutionContext c) {
+                            Yaml.Mapping m = super.visitMapping(mapping, c);
+
+                            if(m == from) {
+                                List<Yaml.Mapping.Entry> entries = new ArrayList<>(m.getEntries());
+                                entries.add(steps.copyPaste().withPrefix("\n"));
+                                m = m.withEntries(entries);
+                            }
+
+                            return m;
+                        }});
+
+                    //TODO might probably change indent in original file, may this happen?
+                    doAfterVisit(new IndentsVisitor(new IndentsStyle(2), null));
+                }
+            };
+        }
+
+}
+

--- a/recipes/src/main/java/io/quarkus/updates/camel30/yaml/CamelQuarkusYamlVisitor.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/yaml/CamelQuarkusYamlVisitor.java
@@ -1,0 +1,34 @@
+package io.quarkus.updates.camel30.yaml;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.yaml.YamlIsoVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+/**
+ * TODO add constraint to runthis recipe only of project contains Camel.
+ */
+public abstract class CamelQuarkusYamlVisitor extends YamlIsoVisitor<ExecutionContext> {
+
+    /**
+     * Method is called before start of visiting a new document.
+     * Implementations might need to clear all local state from previous document.
+     */
+    abstract void clearLocalCache();
+
+    @Override
+    public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext o) {
+        clearLocalCache();
+        Yaml.Document d =  super.visitDocument(document, o);
+        return d;
+    }
+
+    @Override
+    public Yaml.Documents visitDocuments(Yaml.Documents documents, ExecutionContext context) {
+        boolean visited = context.getMessage(CamelQuarkusYamlVisitor.class.getSimpleName() + "_visited", false);
+        if(!visited) {
+            context.putMessage(CamelQuarkusYamlVisitor.class.getSimpleName() + "_visited", true);
+            documents = super.visitDocuments(documents, context);
+        }
+        return documents;
+    }
+}

--- a/recipes/src/main/java/io/quarkus/updates/camel30/yaml/YamlRecipesUtil.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel30/yaml/YamlRecipesUtil.java
@@ -1,0 +1,45 @@
+package io.quarkus.updates.camel30.yaml;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.xml.tree.Xml;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static org.openrewrite.Tree.randomId;
+
+public class YamlRecipesUtil {
+
+    static String getProperty(Cursor cursor) {
+        StringBuilder asProperty = new StringBuilder();
+        Iterator<Object> path = cursor.getPath();
+        int i = 0;
+        while (path.hasNext()) {
+            Object next = path.next();
+            if (next instanceof Yaml.Mapping.Entry) {
+                Yaml.Mapping.Entry entry = (Yaml.Mapping.Entry) next;
+                if (i++ > 0) {
+                    asProperty.insert(0, '.');
+                }
+                asProperty.insert(0, entry.getKey().getValue());
+            }
+        }
+        return asProperty.toString();
+    }
+}

--- a/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus-core/3alpha.yaml
+++ b/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus-core/3alpha.yaml
@@ -1,0 +1,145 @@
+#
+# Copyright 2021 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://github.com/openrewrite/rewrite-migrate-java/blob/main/src/main/resources/META-INF/rewrite/jakarta-ee-9.yml
+# modified to:
+# - use the Jakarta EE 10 versions (except for JPA as we are waiting for the Hibernate ORM 6 upgrade)
+# - not add new dependencies but transform them
+#####
+
+#####
+# Update the Camel - Quarkus extensions
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.camel30.CamelQuarkusMigrationRecipe
+displayName: Migrate `camel3` application to `camel4.`
+description: Migrate `camel3` quarkus application to `camel4` quarkus.
+recipeList:
+  - io.quarkus.updates.camel30.xml.XmlDslRecipe
+  - io.quarkus.updates.camel30.yaml.CamelQuarkusYamlRouteConfigurationSequenceRecipe
+  - io.quarkus.updates.camel30.yaml.CamelQuarkusYamlStepsInFromRecipe
+  - io.quarkus.updates.camel30.java.CamelAPIsRecipe
+  - io.quarkus.updates.camel30.java.CamelEIPRecipe
+  - io.quarkus.updates.camel30.java.CamelBeanRecipe
+  - io.quarkus.updates.camel30.java.CamelHttpRecipe
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.camel.migrate.ChangeTypes
+displayName: Migrate moved types between Came 2.x and Camel 3.x
+description: Change type of classes related to change of API.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.support.IntrospectionSupport
+      newFullyQualifiedTypeName: org.apache.camel.impl.engine.IntrospectionSupport
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.camel.migrate.removedExtensions
+displayName: Remove non existin camel-quarkus extensions
+description: Removal of maven dependencies for extension, which are no longer part of camel 3.x.
+#todo would be better to put a comment about removed extension and possible alternatives, once the openrewrite recipe allows that
+recipeList:
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-activemq
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-activemq
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-atmos
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-avro-rpc
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-caffeine-lrucache
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-datasonnet
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-dozer
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-elasticsearch-rest
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-gora
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-hbase
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-iota
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-jbpm
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-jclouds
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-johnzon
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-microprofile-metrics
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-milo
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-opentracing
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-optaplanner
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-rabbitmq
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-smallrye-reactive-messaging
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-solr
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-tika
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-vm
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-xmlsecurity
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel.quarkus
+      artifactId: camel-quarkus-xstream
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.camel.migrate.ChangePropertyValue
+displayName: Camel API changes in application.properties
+description: Apache Camel API migration from version 3.20 or higher to 4.0. Removal of deprecated APIs, which could be part of the application.properties.
+#todo would be better to put a comment about changed property and its alternative, once the openrewrite recipe allows that
+recipeList:
+  - org.openrewrite.properties.ChangePropertyValue:
+      propertyKey: camel.threadpool.rejectedPolicy
+      newValue: "Abort #DiscardOldest has been removed, consider Abort"
+      oldValue: DiscardOldest
+  - org.openrewrite.properties.ChangePropertyValue:
+        propertyKey: camel.threadpool.rejectedPolicy
+        newValue: "Abort #Discard has been removed, consider Abort"
+        oldValue: Discard


### PR DESCRIPTION
**Descripition:**

PR introduces a recipe - org.apache.camel.quarkus.update.CamelQuarkusMigrationRecipe - which takes care of the whole camel-quarkus migration process. This main recipe registeres all other recipes via the constructor and `doNext` method. If the migrated project contains any camel-quarkus dependency, the child recipes are executed. There are 4 types of camel recipes so far:
Java - recipes migrating java classes. Abstract parent of those recipes detects existence of camel-quarkus import and does nothing if there is no such import
Pom - maven recipes taking care of removed extensions (comments helping users to find replacement are created if possible)
Properties - simple recipe
Yaml - some transformation for YAML DSL feature from Camel
All migration cases are covered by JUnit tests.

**Important features:**

- There are 2 performance optimizations implemented. None of the CQ recipe migrates the code if there is no CQ dependency in the pom. Java recipes are skipped, if the is no import of ‘org.apache.camel’ in the class.
- We upgraded java in this project to have access to String blocks, which are heavily used in the tests.
- PR currently does not contain gradle recipes
- All recipes are grouped together into ‘CamelQuarkusMigrationRecipe`
- Support of maven surefire plugin was added and the test can be executed via `mvn test`

**Opened questions:**

1. How to cover the upgrade process for more versions with the Java recipes avoiding compilation conflicts? (Example from the readme.md: Recipes applied for a project in version 2.7.0.Final updating to 3.1.0.Final (currentVersion=2.7, targetVersion=3.1):2.9.yaml, 3alpha.yaml and 3.1.yaml. Java recipes used in 3alpha.yaml requires camel dependencies 3.18.7 for both tests (and ideally also recipes). But java recipes from 3.1.yaml requires Camel dependencies 4.x. Having both versions 3.x and 4.x on the classpath is not possible.
2. Which java version should be used by this project? Because j15 brings String blocks, which are very helpful in writing junit tests, we upgraded Java. Would this be acceptable?
3. Is it possible to upgrade/use a more recent version of openrewrite? while developing a new recipe we realized it would be nice if we can use the most recent version since it provides many new features which will always be helpful.

**Limitations:**

1. PR does not contain any Gradle recipes.

What do you think @gsmet , @maxandersen, @ia3andy 
