### PR TITLE
Camel-quarkus java migration recipe

### DIFF
--- a/recipes-unit-tests/pom.xml
+++ b/recipes-unit-tests/pom.xml
@@ -89,11 +89,6 @@
             <artifactId>rewrite-java-11</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.openrewrite</groupId>
-            <artifactId>rewrite-java-17</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- rewrite-maven dependency only necessary for Maven Recipe development -->
         <dependency>
@@ -208,7 +203,6 @@
             <version>${http.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelJavaTest.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/camel30/CamelJavaTest.java
@@ -1,0 +1,84 @@
+package io.quarkus.updates.camel30;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.properties.Assertions;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CamelJavaTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelQuarkusTestUtil.recipe(spec, "org.openrewrite.java.migrate.UpgradeJavaVersion")
+                .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testJava17Update() {
+        rewriteRun(
+                org.openrewrite.maven.Assertions.pomXml(
+                        """
+                                <project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">
+                                    <modelVersion>4.0.0</modelVersion>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <version>2.13.4-SNAPSHOT</version>
+                                    <artifactId>camel-quarkus-migration-test-microprofile</artifactId>
+                                    <properties>
+                                        <maven.compiler.source>11</maven.compiler.source>
+                                        <maven.compiler.target>11</maven.compiler.target>
+                                    </properties>
+                                   <dependencyManagement>
+                                       <dependencies>
+                                           <dependency>
+                                               <groupId>io.quarkus.platform</groupId>
+                                               <artifactId>quarkus-camel-bom</artifactId>
+                                               <version>2.13.3.Final</version>
+                                               <type>pom</type>
+                                               <scope>import</scope>
+                                           </dependency>
+                                       </dependencies>
+                                   </dependencyManagement>
+                                    <dependencies>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-bean</artifactId>
+                                        </dependency>
+                                    </dependencies>
+                                </project>
+                                """
+                        , """
+                                <project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">
+                                    <modelVersion>4.0.0</modelVersion>
+                                    <groupId>org.apache.camel.quarkus</groupId>
+                                    <version>2.13.4-SNAPSHOT</version>
+                                    <artifactId>camel-quarkus-migration-test-microprofile</artifactId>
+                                    <properties>
+                                        <maven.compiler.source>17</maven.compiler.source>
+                                        <maven.compiler.target>17</maven.compiler.target>
+                                    </properties>
+                                   <dependencyManagement>
+                                       <dependencies>
+                                           <dependency>
+                                               <groupId>io.quarkus.platform</groupId>
+                                               <artifactId>quarkus-camel-bom</artifactId>
+                                               <version>2.13.3.Final</version>
+                                               <type>pom</type>
+                                               <scope>import</scope>
+                                           </dependency>
+                                       </dependencies>
+                                   </dependencyManagement>
+                                    <dependencies>
+                                        <dependency>
+                                            <groupId>org.apache.camel.quarkus</groupId>
+                                            <artifactId>camel-quarkus-bean</artifactId>
+                                        </dependency>
+                                    </dependencies>
+                                </project>
+                                """)
+        );
+    }
+
+}


### PR DESCRIPTION
Verification of https://github.com/quarkusio/quarkus-updates/issues/50

@ia3andy I removed the unnecessary dependency and added a test covering javsa upgrade from  11 to 17. My local execution fails . Is this case also coveredby default recipes? To my knowledge the upgrade of java to 17 was not supported by the tool because of a decision, but this information might be old and wrong one.

If the upgrade to 17 is not globally forced, we should add following recipe int camel-quarkus recipes


```
type: specs.openrewrite.org/v1beta/recipe
name: org.openrewrite.java.migrate.UpgradeJavaVersion
displayName: Migrate java from to 17
description: Migration of java  (from 11 to 17) for Camel applications, if necessary.
recipeList:
  - org.openrewrite.java.migrate.UpgradeJavaVersion:
      version: 17
---
```