### PR TITLE
Rewrite mutiny deprecation for reworked Uni combination APIs

### DIFF
--- a/recipes/src/main/resources/quarkus-updates/core/3.5.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.5.yaml
@@ -1,0 +1,10 @@
+#####
+# Replace io.smallrye.mutiny.groups.UniAndGroup*.combinedWith(..) with io.smallrye.mutiny.groups.UniAndGroup*.with(..)
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus35.MutinyUniAndGroupCombinedWith
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: io.smallrye.mutiny.groups.UniAndGroup* combinedWith(..)
+      newMethodName: with

--- a/recipes/src/main/resources/quarkus-updates/core/3.5.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.5.yaml
@@ -8,3 +8,14 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: io.smallrye.mutiny.groups.UniAndGroup* combinedWith(..)
       newMethodName: with
+
+#####
+# Replace io.smallrye.mutiny.groups.UniMemoize.atLeast(..) with io.smallrye.mutiny.groups.UniMemoize.forFixedDuration(..)
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus35.MutinyUniMemoizeAtLeast
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: io.smallrye.mutiny.groups.UniMemoize atLeast(..)
+      newMethodName: forFixedDuration


### PR DESCRIPTION
See https://github.com/smallrye/smallrye-mutiny/releases/tag/2.5.0 and https://github.com/smallrye/smallrye-mutiny/pull/1362

Not sure if it belongs here, but I couldn't find any place for Mutiny rewrites itself.

Tested this on one of my local projects and simply rewrites the methods from `combinedWith` to `with` and compiles successfully without any deprecation warnings afterwards with Quarkus 3.5.0