### PR TITLE
Track Gradle plugin version just as we do Maven

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -9,8 +9,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <!-- This artifact is there only to get Dependabot to track the Maven plugin dependency -->
-    <!-- We cannot do the same for the Gradle plugin unfortunately so we will have to keep track of it manually -->
+    <!-- This artifact is there only to get Dependabot to track the Maven and Gradle plugin dependency -->
     <artifactId>quarkus-plugins</artifactId>
     <name>Quarkus Updates - Plugins</name>
 
@@ -29,5 +28,18 @@
             <version>${rewrite-maven-plugin.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>plugin</artifactId>
+            <version>${rewrite-gradle-plugin.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>plugins.gradle.org</id>
+            <url>https://plugins.gradle.org/m2/</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
There was a note saying this was not possible, but I think it might through the added repository, if that had not been tried already.