### PR TITLE
Bump maven-compiler-plugin to 3.12.1

### DIFF
--- a/recipes/src/main/resources/quarkus-updates/core/3.7.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.7.yaml
@@ -13,3 +13,7 @@ recipeList:
       oldPackageName: org.hibernate.search.mapper.orm.coordination.outboxpolling
       newPackageName: org.hibernate.search.mapper.orm.outboxpolling
       recursive: true
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-compiler-plugin
+      newVersion: 3.12.1


### PR DESCRIPTION
- Required for https://github.com/quarkusio/quarkus/issues/37477

Recipe documentation in https://docs.openrewrite.org/recipes/maven/upgradepluginversion