### PR TITLE
Add recipes to rename resteasy-client dependencies

### DIFF
--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/core/CoreTestUtil.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/core/CoreTestUtil.java
@@ -1,17 +1,27 @@
 package io.quarkus.updates.core;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 import java.util.Properties;
 
 import org.openrewrite.Recipe;
+import org.openrewrite.config.CompositeRecipe;
+import org.openrewrite.config.Environment;
 import org.openrewrite.config.YamlResourceLoader;
+import org.openrewrite.maven.ChangePropertyValue;
 import org.openrewrite.test.RecipeSpec;
 
-public class CoreTestUtil {
+public final class CoreTestUtil {
+
+    private CoreTestUtil() {
+    }
 
     public static RecipeSpec recipe(RecipeSpec spec, Path recipeFile) {
         try (InputStream yamlRecipeInputStream = CoreTestUtil.class.getClassLoader().getResourceAsStream(recipeFile.toString())) {
@@ -23,5 +33,32 @@ public class CoreTestUtil {
         } catch (IOException e) {
             throw new UncheckedIOException("Unable to open recipe file " + recipeFile, e);
         }
+    }
+
+    public static RecipeSpec recipe(RecipeSpec spec, Path recipeFile, String quarkusVersion) {
+        try (InputStream yamlRecipeInputStream = CoreTestUtil.class.getClassLoader().getResourceAsStream(recipeFile.toString())) {
+            YamlResourceLoader yamlResourceLoader = new YamlResourceLoader(yamlRecipeInputStream, recipeFile.toUri(), new Properties());
+            String[] recipeNames = yamlResourceLoader.listRecipes().stream()
+                    .map(r -> r.getName()).toArray(String[]::new);
+
+            Recipe updateQuarkusRecipe = updateQuarkus(quarkusVersion);
+            Recipe updateRecipes = recipeFromResource(Path.of("/").resolve(recipeFile).toAbsolutePath().toString(), recipeNames);
+
+            return spec.recipes(updateQuarkusRecipe, updateRecipes);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Unable to open recipe file " + recipeFile, e);
+        }
+    }
+
+    private static Recipe updateQuarkus(String quarkusVersion) {
+        return new CompositeRecipe(List.of(new ChangePropertyValue("quarkus.version", quarkusVersion, null, null),
+                new ChangePropertyValue("quarkus.platform.version", quarkusVersion, null, null)));
+    }
+
+    private static Recipe recipeFromResource(String yamlResource, String... activeRecipes) {
+        return Environment.builder()
+                .load(new YamlResourceLoader(RecipeSpec.class.getResourceAsStream(yamlResource), URI.create("rewrite.yml"), new Properties()))
+                .build()
+                .activateRecipes(activeRecipes);
     }
 }

--- a/recipes-unit-tests/src/test/java/io/quarkus/updates/core/CoreUpdate37Test.java
+++ b/recipes-unit-tests/src/test/java/io/quarkus/updates/core/CoreUpdate37Test.java
@@ -4,6 +4,7 @@ import static org.openrewrite.maven.Assertions.pomXml;
 
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -14,7 +15,7 @@ public class CoreUpdate37Test implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        CoreTestUtil.recipe(spec, Path.of("quarkus-updates", "core", "3.7.yaml"))
+        CoreTestUtil.recipe(spec, Path.of("quarkus-updates", "core", "3.7.yaml"), "3.7.0")
                 .parser(JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true))
                 .typeValidationOptions(TypeValidation.none());
     }
@@ -81,7 +82,6 @@ public class CoreUpdate37Test implements RewriteTest {
                     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
                     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
                     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-                    <quarkus.platform.version>3.6.4</quarkus.platform.version>
                     <skipITs>true</skipITs>
                     <surefire-plugin.version>3.1.2</surefire-plugin.version>
                 </properties>
@@ -126,7 +126,6 @@ public class CoreUpdate37Test implements RewriteTest {
                     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
                     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
                     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-                    <quarkus.platform.version>3.6.4</quarkus.platform.version>
                     <skipITs>true</skipITs>
                     <surefire-plugin.version>3.2.3</surefire-plugin.version>
                 </properties>
@@ -176,7 +175,6 @@ public class CoreUpdate37Test implements RewriteTest {
                     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
                     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
                     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-                    <quarkus.platform.version>3.6.4</quarkus.platform.version>
                     <skipITs>true</skipITs>
                     <surefire-plugin.version>3.1.2</surefire-plugin.version>
                 </properties>
@@ -219,7 +217,6 @@ public class CoreUpdate37Test implements RewriteTest {
                     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
                     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
                     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-                    <quarkus.platform.version>3.6.4</quarkus.platform.version>
                     <skipITs>true</skipITs>
                     <surefire-plugin.version>3.2.3</surefire-plugin.version>
                 </properties>
@@ -812,6 +809,100 @@ public class CoreUpdate37Test implements RewriteTest {
                             </plugin>
                         </plugins>
                     </build>
+                </project>
+                """));
+    }
+
+    @Test
+    @Disabled("Pending the release of 3.7.0")
+    void testResteasyClientRenaming() {
+        //language=xml
+        rewriteRun(pomXml("""
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>io.quarkus.bot</groupId>
+                    <artifactId>release</artifactId>
+                    <version>999-SNAPSHOT</version>
+                    <properties>
+                        <quarkus.version>3.6.4</quarkus.version>
+                    </properties>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.quarkus</groupId>
+                                <artifactId>quarkus-bom</artifactId>
+                                <version>${quarkus.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-rest-client</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-rest-client-jackson</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-rest-client-jaxb</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-rest-client-jsonb</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-rest-client-mutiny</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+                """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>io.quarkus.bot</groupId>
+                    <artifactId>release</artifactId>
+                    <version>999-SNAPSHOT</version>
+                    <properties>
+                        <quarkus.version>3.7.0</quarkus.version>
+                    </properties>
+                    <dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.quarkus</groupId>
+                                <artifactId>quarkus-bom</artifactId>
+                                <version>${quarkus.version}</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                            </dependency>
+                        </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-resteasy-client</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-resteasy-client-jackson</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-resteasy-client-jaxb</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-resteasy-client-jsonb</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-resteasy-client-mutiny</artifactId>
+                        </dependency>
+                    </dependencies>
                 </project>
                 """));
     }

--- a/recipes/src/main/resources/quarkus-updates/core/3.7.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.7.yaml
@@ -15,6 +15,34 @@ recipeList:
       recursive: true
 
 #####
+# Adjust artifact for REST Client -> RESTEasy Client renaming
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus37.ResteasyClientRenaming
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-rest-client
+      newArtifactId: quarkus-resteasy-client
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-rest-client-jackson
+      newArtifactId: quarkus-resteasy-client-jackson
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-rest-client-jaxb
+      newArtifactId: quarkus-resteasy-client-jaxb
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-rest-client-jsonb
+      newArtifactId: quarkus-resteasy-client-jsonb
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-rest-client-mutiny
+      newArtifactId: quarkus-resteasy-client-mutiny
+
+#####
 # Update Maven plugins
 #####
 ---


### PR DESCRIPTION
The test is disabled until we have a 3.7.0 around.