### PR TITLE
Do not assert JBang output

### DIFF
--- a/recipes-tests/src/test/java/io/quarkus/updates/integration/UpdateProjectIT.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/integration/UpdateProjectIT.java
@@ -115,8 +115,7 @@ public class UpdateProjectIT {
 
     static void trustQuarkusRepo(Path tempDir) throws IOException, InterruptedException, TimeoutException {
         if (!quarkusRepoTrusted) {
-            String trust = jbang(tempDir, "trust", "add", MAVEN_CENTRAL_QUARKUS_REPO);
-            assertThat(trust).matches(Pattern.compile("(?s).*\\[jbang\\] Trusting permanently: \\["+MAVEN_CENTRAL_QUARKUS_REPO+ "\\].*"));
+            jbang(tempDir, "trust", "add", MAVEN_CENTRAL_QUARKUS_REPO);
             quarkusRepoTrusted = true;
         }
     }


### PR DESCRIPTION
This is an infrastructure thing and not really related to what we are supposed to test and I already had to tweak it once and now I have: [WARN] Already trusted source(s). No changes made. when trying to release, which doesn't match the assert.