### PR TITLE
Some missing recipes for upgrading to camel 4.0

### DIFF
--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelAPIsTest.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelAPIsTest.java
@@ -544,6 +544,132 @@ public class CamelAPIsTest implements RewriteTest {
     }
 
     @Test
+    void testModelJAXBContextFactoryViaPluginHelper() {
+        //language=java
+        rewriteRun(java("""
+                            package org.apache.camel.quarkus.component.test.it;
+
+                            import org.apache.camel.CamelContext;
+                            import org.apache.camel.ExtendedCamelContext;
+                            import org.apache.camel.spi.ModelJAXBContextFactory;
+                            
+                            public class Test {
+                                
+                                ExtendedCamelContext ecc;
+                                CamelContext context;
+
+                                public void test() {
+                                    ModelJAXBContextFactory jcf = ecc.getModelJAXBContextFactory();
+                                    ModelJAXBContextFactory jcf2  = context.getExtension(ExtendedCamelContext.class).getModelJAXBContextFactory();
+                                }
+                            }
+                        """,
+                """
+                        package org.apache.camel.quarkus.component.test.it;
+    
+                        import org.apache.camel.CamelContext;
+                        import org.apache.camel.ExtendedCamelContext;
+                        import org.apache.camel.spi.ModelJAXBContextFactory;
+                        import org.apache.camel.support.PluginHelper;
+                        
+                        public class Test {
+                            
+                            ExtendedCamelContext ecc;
+                            CamelContext context;
+    
+                            public void test() {
+                                ModelJAXBContextFactory jcf = PluginHelper.getModelJAXBContextFactory(ecc);
+                                ModelJAXBContextFactory jcf2  = PluginHelper.getModelJAXBContextFactory(context);
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void testModelToXMLDumperViaPluginHelper() {
+        //language=java
+        rewriteRun(java("""
+                            package org.apache.camel.quarkus.component.test.it;
+
+                            import org.apache.camel.CamelContext;
+                            import org.apache.camel.ExtendedCamelContext;
+                            import org.apache.camel.spi.ModelToXMLDumper;
+                            
+                            public class Test {
+                                
+                                ExtendedCamelContext ecc;
+                                CamelContext context;
+
+                                public void test() {
+                                    ModelToXMLDumper xd = ecc.getModelToXMLDumper();
+                                    ModelToXMLDumper xd2  = context.getExtension(ExtendedCamelContext.class).getModelToXMLDumper();
+                                }
+                            }
+                        """,
+                """
+                        package org.apache.camel.quarkus.component.test.it;
+    
+                        import org.apache.camel.CamelContext;
+                        import org.apache.camel.ExtendedCamelContext;
+                        import org.apache.camel.spi.ModelToXMLDumper;
+                        import org.apache.camel.support.PluginHelper;
+                        
+                        public class Test {
+                            
+                            ExtendedCamelContext ecc;
+                            CamelContext context;
+    
+                            public void test() {
+                                ModelToXMLDumper xd = PluginHelper.getModelToXMLDumper(ecc);
+                                ModelToXMLDumper xd2  = PluginHelper.getModelToXMLDumper(context);
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void getRoutesLoaderViaPluginHelper() {
+        //language=java
+        rewriteRun(java("""
+                            package org.apache.camel.quarkus.component.test.it;
+
+                            import org.apache.camel.CamelContext;
+                            import org.apache.camel.ExtendedCamelContext;
+                            import org.apache.camel.spi.RoutesLoader;
+                            
+                            public class Test {
+                                
+                                ExtendedCamelContext ecc;
+                                CamelContext context;
+
+                                public void test() {
+                                    RoutesLoader rl = ecc.getRoutesLoader();
+                                    RoutesLoader rl  = context.getExtension(ExtendedCamelContext.class).getRoutesLoader();
+                                }
+                            }
+                        """,
+                """
+                        package org.apache.camel.quarkus.component.test.it;
+    
+                        import org.apache.camel.CamelContext;
+                        import org.apache.camel.ExtendedCamelContext;
+                        import org.apache.camel.spi.RoutesLoader;
+                        import org.apache.camel.support.PluginHelper;
+                        
+                        public class Test {
+                            
+                            ExtendedCamelContext ecc;
+                            CamelContext context;
+    
+                            public void test() {
+                                RoutesLoader rl = PluginHelper.getRoutesLoader(ecc);
+                                RoutesLoader rl  = PluginHelper.getRoutesLoader(context);
+                            }
+                        }
+                        """));
+    }
+
+    @Test
     void testRuntimeCatalog() {
         //language=java
         rewriteRun(java(

--- a/recipes/src/main/java/io/quarkus/updates/camel/camel40/java/CamelAPIsRecipe.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel/camel40/java/CamelAPIsRecipe.java
@@ -43,7 +43,6 @@ public class CamelAPIsRecipe extends Recipe {
 
     private static final String MATCHER_CONTEXT_GET_ENDPOINT_MAP = "org.apache.camel.CamelContext getEndpointMap()";
     private static final String MATCHER_CONTEXT_GET_EXT = "org.apache.camel.CamelContext getExtension(java.lang.Class)";
-    private static final String MATCHER_GET_NAME_RESOLVER = "org.apache.camel.ExtendedCamelContext getComponentNameResolver()";
     private static final String M_PRODUCER_TEMPLATE_ASYNC_CALLBACK = "org.apache.camel.ProducerTemplate asyncCallback(..)";
     private static final String M_CONTEXT_ADAPT = "org.apache.camel.CamelContext adapt(java.lang.Class)";
     private static final String M_CONTEXT_SET_DUMP_ROUTES = "org.apache.camel.CamelContext setDumpRoutes(java.lang.Boolean)";
@@ -290,17 +289,6 @@ public class CamelAPIsRecipe extends Recipe {
                 //Boolean isDumpRoutes(); -> getDumpRoutes(); with returned type String
                 else if(getMethodMatcher(M_CONTEXT_IS_DUMP_ROUTES).matches(mi, false)) {
                     mi = mi.withName(mi.getName().withSimpleName("getDumpRoutes")).withComments(Collections.singletonList(RecipesUtil.createMultinlineComment(" Method 'getDumpRoutes' returns String value ('xml' or 'yaml' or 'false'). ")));
-                }
-                // context.getExtension(ExtendedCamelContext.class).getComponentNameResolver() -> PluginHelper.getComponentNameResolver(context)
-                else if (getMethodMatcher(MATCHER_GET_NAME_RESOLVER).matches(mi)) {
-                    if (mi.getSelect() instanceof J.MethodInvocation && getMethodMatcher(MATCHER_CONTEXT_GET_EXT).matches(((J.MethodInvocation) mi.getSelect()).getMethodType())) {
-                        J.MethodInvocation innerInvocation = (J.MethodInvocation) mi.getSelect();
-                        mi = JavaTemplate.builder("PluginHelper.getComponentNameResolver(#{any(org.apache.camel.CamelContext)})")
-                                //.contextSensitive()
-                                .build()
-                                .apply(getCursor(), mi.getCoordinates().replace(), innerInvocation.getSelect());
-                        doAfterVisit(new AddImport<>("org.apache.camel.support.PluginHelper", null, false));
-                    }
                 }
                 // (CamelRuntimeCatalog) context.getExtension(RuntimeCamelCatalog.class) -> context.getCamelContextExtension().getContextPlugin(RuntimeCamelCatalog.class);
                 else if (getMethodMatcher(MATCHER_CONTEXT_GET_EXT).matches(mi, false)) {

--- a/recipes/src/main/java/io/quarkus/updates/camel/customRecipes/MoveGetterToPluginHelper.java
+++ b/recipes/src/main/java/io/quarkus/updates/camel/customRecipes/MoveGetterToPluginHelper.java
@@ -1,0 +1,83 @@
+package io.quarkus.updates.camel.customRecipes;
+
+import io.quarkus.updates.camel.AbstractCamelQuarkusJavaVisitor;
+import io.quarkus.updates.camel.RecipesUtil;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AddImport;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+
+import java.util.regex.Pattern;
+
+/**
+ * Replaces prefix with the new one and changes the suffix tp start with lower case
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class MoveGetterToPluginHelper extends Recipe {
+
+    private static final String MATCHER_GET_NAME_RESOLVER = "org.apache.camel.ExtendedCamelContext getComponentNameResolver()";
+    private static final String MATCHER_GET_MODEL_JAXB_CONTEXT_FACTORY = "org.apache.camel.ExtendedCamelContext getModelJAXBContextFactory()";
+    private static final String MATCHER_GET_MODEL_TO_XML_DUMPER = "org.apache.camel.ExtendedCamelContext getModelToXMLDumper()";
+    private static final Pattern EXTERNAL_CONTEXT_TYPE = Pattern.compile("org.apache.camel.ExtendedCamelContext");
+    private static final String MATCHER_CONTEXT_GET_EXT = "org.apache.camel.CamelContext getExtension(java.lang.Class)";
+
+    @Option(displayName = "Method name",
+            description = "Name of the method on external camel context.")
+    String oldMethodName;
+
+    @Override
+    public String getDisplayName() {
+        return "Move getter from context to PluginHelper.";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Move getter from context to PluginHelper";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return RecipesUtil.newVisitor(new AbstractCamelQuarkusJavaVisitor() {
+            @Override
+            protected J.MethodInvocation doVisitMethodInvocation(J.MethodInvocation method, ExecutionContext context) {
+                J.MethodInvocation mi = super.doVisitMethodInvocation(method, context);
+
+                // extendedContext.getModelJAXBContextFactory() -> PluginHelper.getModelJAXBContextFactory(extendedContext)
+                if (getMethodMatcher(getOldMethodMatcher()).matches(mi, false)) {
+                    if (mi.getSelect() instanceof J.MethodInvocation && getMethodMatcher(MATCHER_CONTEXT_GET_EXT).matches(((J.MethodInvocation) mi.getSelect()).getMethodType())) {
+                        J.MethodInvocation innerInvocation = (J.MethodInvocation) mi.getSelect();
+                        mi = JavaTemplate.builder(getNewMethodFromContext())
+                                //.contextSensitive()
+                                .build()
+                                .apply(getCursor(), mi.getCoordinates().replace(), innerInvocation.getSelect());
+                        doAfterVisit(new AddImport<>("org.apache.camel.support.PluginHelper", null, false));
+                    } else if (mi.getSelect().getType().isAssignableFrom(EXTERNAL_CONTEXT_TYPE)) {
+                        mi = JavaTemplate.builder(getNewMethodFromExternalContextContext())
+                                //.contextSensitive()
+                                .build()
+                                .apply(getCursor(), mi.getCoordinates().replace(), mi.getSelect());
+                        doAfterVisit(new AddImport<>("org.apache.camel.support.PluginHelper", null, false));
+                    }
+                }
+
+                return mi;
+            }
+
+            private String getOldMethodMatcher() {
+                return "org.apache.camel.ExtendedCamelContext " + oldMethodName + "()";
+            }
+            private String getNewMethodFromContext() {
+                return "PluginHelper." + oldMethodName + "(#{any(org.apache.camel.CamelContext)})";
+            }
+            private String getNewMethodFromExternalContextContext() {
+                return "PluginHelper." + oldMethodName + "(#{any(org.apache.camel.ExtendedCamelContext)})";
+            }
+        });
+    }
+}

--- a/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3alpha.yaml
+++ b/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3alpha.yaml
@@ -43,6 +43,7 @@ recipeList:
   - io.quarkus.updates.camel.camel40.java.CamelEIPRecipe
   - io.quarkus.updates.camel.camel40.java.CamelBeanRecipe
   - io.quarkus.updates.camel.camel40.java.CamelHttpRecipe
+  - io.quarkus.updates.camel.camel40.UsePluginHelperForContextGetters
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.camel.migrate.ChangeTypes
@@ -171,3 +172,16 @@ recipeList:
       newMethodName: extendedInformation
       matchOverrides: null
       ignoreDefinition: null
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.camel.camel40.UsePluginHelperForContextGetters
+displayName: Replace context.getExtension(ExtendedCamelContext.class).get* with PluginHelper.get*(context)
+recipeList:
+  - io.quarkus.updates.camel.customRecipes.MoveGetterToPluginHelper:
+      oldMethodName: getComponentNameResolver
+  - io.quarkus.updates.camel.customRecipes.MoveGetterToPluginHelper:
+      oldMethodName: getModelJAXBContextFactory
+  - io.quarkus.updates.camel.customRecipes.MoveGetterToPluginHelper:
+      oldMethodName: getModelToXMLDumper
+  - io.quarkus.updates.camel.customRecipes.MoveGetterToPluginHelper:
+      oldMethodName: getRoutesLoader


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus-updates/issues/170

Part of the `CamelAPIRecipe` is refactored to custom recipe (`MoveGetterToPluginHelper.java`), which is registered several times in `3alpha.yaml`