### PR TITLE
Update camel-upgrade-recipes to 4.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!--   https://plugins.gradle.org/plugin/org.openrewrite.rewrite -->
         <rewrite-gradle-plugin.version>6.18.0</rewrite-gradle-plugin.version>
         <!-- https://github.com/apache/camel-upgrade-recipes -->
-        <camel-upgrade-recipes.version>0.1</camel-upgrade-recipes.version>
+        <camel-upgrade-recipes.version>4.8.0</camel-upgrade-recipes.version>
         <!-- align with https://central.sonatype.com/artifact/org.openrewrite/rewrite-core -->
         <micrometer-core.version>1.9.17</micrometer-core.version>
         <!-- tests-->

--- a/recipes-tests/pom.xml
+++ b/recipes-tests/pom.xml
@@ -32,6 +32,8 @@
         <test.camel-quarkus-3-0.http-client-version>4.5.14</test.camel-quarkus-3-0.http-client-version>
         <test.camel-quarkus-3-0.http-core-version>4.4.16</test.camel-quarkus-3-0.http-core-version>
         <test.camel-quarkus-3-8.camel-version>4.0.3</test.camel-quarkus-3-8.camel-version>
+        <test.camel-quarkus-3-15.camel-version>4.8.0</test.camel-quarkus-3-15.camel-version>
+        <test.camel-quarkus-3-15.jakarta-servlet-api-version>6.0.0</test.camel-quarkus-3-15.jakarta-servlet-api-version>
 
     </properties>
 
@@ -167,7 +169,7 @@
 
         <!-- Recipes for testing camel-quarkus -->
         <dependency>
-            <groupId>org.apache.camel</groupId>
+            <groupId>org.apache.camel.upgrade</groupId>
             <artifactId>camel-upgrade-recipes</artifactId>
             <version>${camel-upgrade-recipes.version}</version>
             <scope>test</scope>
@@ -309,7 +311,7 @@
                                     <version>${test.camel-quarkus-3-0.camel-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
-                                <!--3.18 non-camel dependencies-->
+                                <!--3.8 non-camel dependencies-->
                                 <artifactItem>
                                     <groupId>org.apache.httpcomponents</groupId>
                                     <artifactId>httpclient</artifactId>
@@ -322,13 +324,7 @@
                                     <version>${test.camel-quarkus-3-0.http-core-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
-                                <!-- camel 4.0 dependencies-->
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-api</artifactId>
-                                    <version>${test.camel-quarkus-3-8.camel-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
+                                <!-- camel quarkus 3.8 test dependencies-->
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-base</artifactId>
@@ -344,12 +340,6 @@
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-endpointdsl</artifactId>
-                                    <version>${test.camel-quarkus-3-8.camel-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-core-model</artifactId>
                                     <version>${test.camel-quarkus-3-8.camel-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
@@ -373,20 +363,51 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-support</artifactId>
-                                    <version>${test.camel-quarkus-3-8.camel-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-tracing</artifactId>
                                     <version>${test.camel-quarkus-3-8.camel-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-util</artifactId>
+                                    <artifactId>camel-spring-redis</artifactId>
                                     <version>${test.camel-quarkus-3-8.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-opensearch</artifactId>
+                                    <version>${test.camel-quarkus-3-8.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-elasticsearch</artifactId>
+                                    <version>${test.camel-quarkus-3-8.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <!-- camel quarkus 3.15 test dependencies-->
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-elasticsearch</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-http-common</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-undertow</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.servlet</groupId>
+                                    <artifactId>jakarta.servlet-api</artifactId>
+                                    <version>${test.camel-quarkus-3-15.jakarta-servlet-api-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelQuarkusTestUtil.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelQuarkusTestUtil.java
@@ -19,17 +19,27 @@ public class CamelQuarkusTestUtil {
     }
 
     public static RecipeSpec recipe3_8(RecipeSpec spec, String... activeRecipes) {
+        return recipeForVersion("3.8", spec, activeRecipes);
+    }
+
+    public static RecipeSpec recipe3_15(RecipeSpec spec, String... activeRecipes) {
+        return recipeForVersion("3.15", spec, activeRecipes);
+    }
+
+    private static RecipeSpec recipeForVersion(String version, RecipeSpec spec, String... activeRecipes) {
         if(activeRecipes.length == 0) {
-            return recipe(spec, "3.8");
+            return recipe(spec, version);
         }
 
-       return recipe(spec, "3.8", activeRecipes);
+       return recipe(spec, version, activeRecipes);
     }
+
 
     private static RecipeSpec recipe(RecipeSpec spec, String version) {
         String[] defaultRecipes = switch (version) {
             case "3.8" -> new String[] {"io.quarkus.updates.camel.camel44.CamelQuarkusMigrationRecipe"};
             case "3alpha" -> new String[] {"io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe"};
+            case "3.15" -> new String[] {"io.quarkus.updates.camel.camel47.CamelQuarkusMigrationRecipe"};
             default -> throw new IllegalArgumentException("Version '" + version + "' is not allowed!");
         };
         return recipe(spec, version, defaultRecipes);

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate41Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate41Test.java
@@ -3,7 +3,7 @@ package io.quarkus.updates.camel;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelUpdate41Test extends org.apache.camel.updates.camel44.CamelUpdate41Test {
+public class CamelUpdate41Test extends org.apache.camel.upgrade.camel44.CamelUpdate41Test {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate42Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate42Test.java
@@ -5,7 +5,7 @@ import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class CamelUpdate42Test extends org.apache.camel.updates.camel44.CamelUpdate42Test {
+public class CamelUpdate42Test extends org.apache.camel.upgrade.camel44.CamelUpdate42Test {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate43Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate43Test.java
@@ -3,7 +3,7 @@ package io.quarkus.updates.camel;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelUpdate43Test extends org.apache.camel.updates.camel44.CamelUpdate43Test {
+public class CamelUpdate43Test extends org.apache.camel.upgrade.camel44.CamelUpdate43Test {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate44Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate44Test.java
@@ -3,7 +3,7 @@ package io.quarkus.updates.camel;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelUpdate44Test extends org.apache.camel.updates.camel44.CamelUpdate44Test {
+public class CamelUpdate44Test extends org.apache.camel.upgrade.camel44.CamelUpdate44Test {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate45Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate45Test.java
@@ -1,0 +1,46 @@
+package io.quarkus.updates.camel;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class CamelUpdate45Test extends org.apache.camel.upgrade.CamelUpdate45Test {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        //let the parser be initialized in the camel parent
+        super.defaults(spec);
+        //recipe has to be loaded differently
+        CamelQuarkusTestUtil.recipe3_15(spec)
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    @Override
+    public void testSearch() {
+        //test has to be changed, because the result of camel 4.5 migration is a;so migrated in camel 4.6,
+        // therefore camel-quarkus migration from 3.8 to 3.15 has to expect both changes
+        rewriteRun(java(
+                """
+                            public class SearchTest {
+                                 public void test() {
+                             
+                                     org.apache.camel.component.es.aggregation.BulkRequestAggregationStrategy elasticAggregationStrategy = null;
+                                     org.apache.camel.component.opensearch.aggregation.BulkRequestAggregationStrategy openAggregationStrategy = null;
+                                 }
+                            }
+                        """,
+                """
+                            public class SearchTest {
+                                 public void test() {
+                            
+                                     org.apache.camel.component.es.aggregation.ElasticsearchBulkRequestAggregationStrategy elasticAggregationStrategy = null;
+                                     org.apache.camel.component.opensearch.aggregation.OpensearchBulkRequestAggregationStrategy openAggregationStrategy = null;
+                                 }
+                            }
+                        """));
+    }
+}

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate46Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate46Test.java
@@ -1,0 +1,37 @@
+package io.quarkus.updates.camel;
+
+import org.junit.jupiter.api.Disabled;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.TypeValidation;
+
+public class CamelUpdate46Test extends org.apache.camel.upgrade.CamelUpdate46Test {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        //let the parser be initialized in the camel parent
+        super.defaults(spec);
+        //recipe has to be loaded differently
+        CamelQuarkusTestUtil.recipe3_15(spec)
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    //following tests have to be disabled, the migration they cover is happening only between Camel 4.5-4.6
+    // module which introduced the code before migration does not exist in Camel 4.4 (which is used by camel-quarkus 3.8)
+    @Disabled
+    @Override
+    public void testLangchainEmbeddings() {
+    }
+
+    @Disabled
+    @Override
+    public void testLangchainChat() {
+
+    }
+
+    //followig test is covered by CamelUpdate45Test.testSearch
+    @Disabled
+    @Override
+    public void testSearch() {
+        super.testSearch();
+    }
+}

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate47Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate47Test.java
@@ -1,17 +1,16 @@
-package io.quarkus.updates.camel.camel40;
+package io.quarkus.updates.camel;
 
-import io.quarkus.updates.camel.CamelQuarkusTestUtil;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CameXmlDslRecipeTest extends org.apache.camel.upgrade.camel40.CameXmlDslRecipeTest {
+public class CamelUpdate47Test extends org.apache.camel.upgrade.CamelUpdate47Test {
 
     @Override
     public void defaults(RecipeSpec spec) {
         //let the parser be initialized in the camel parent
         super.defaults(spec);
         //recipe has to be loaded differently
-        CamelQuarkusTestUtil.recipe3alpha(spec)
+        CamelQuarkusTestUtil.recipe3_15(spec)
                 .typeValidationOptions(TypeValidation.none());
     }
 }

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelAPIsPropertiesTest.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelAPIsPropertiesTest.java
@@ -4,7 +4,7 @@ import io.quarkus.updates.camel.CamelQuarkusTestUtil;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelAPIsPropertiesTest extends org.apache.camel.updates.camel40.CamelAPIsPropertiesTest {
+public class CamelAPIsPropertiesTest extends org.apache.camel.upgrade.camel40.CamelAPIsPropertiesTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelAPIsTest.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelAPIsTest.java
@@ -4,7 +4,7 @@ import io.quarkus.updates.camel.CamelQuarkusTestUtil;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelAPIsTest extends org.apache.camel.updates.camel40.CamelAPIsTest {
+public class CamelAPIsTest extends org.apache.camel.upgrade.camel40.CamelAPIsTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelBeanRecipeTest.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelBeanRecipeTest.java
@@ -4,7 +4,7 @@ import io.quarkus.updates.camel.CamelQuarkusTestUtil;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelBeanRecipeTest extends org.apache.camel.updates.camel40.CamelBeanRecipeTest {
+public class CamelBeanRecipeTest extends org.apache.camel.upgrade.camel40.CamelBeanRecipeTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelEIPRecipeTest.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelEIPRecipeTest.java
@@ -4,7 +4,7 @@ import io.quarkus.updates.camel.CamelQuarkusTestUtil;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelEIPRecipeTest extends org.apache.camel.updates.camel40.CamelEIPRecipeTest {
+public class CamelEIPRecipeTest extends org.apache.camel.upgrade.camel40.CamelEIPRecipeTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelHttpTest.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelHttpTest.java
@@ -4,7 +4,7 @@ import io.quarkus.updates.camel.CamelQuarkusTestUtil;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelHttpTest extends org.apache.camel.updates.camel40.CamelHttpTest {
+public class CamelHttpTest extends org.apache.camel.upgrade.camel40.CamelHttpTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelJmxTest.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelJmxTest.java
@@ -4,7 +4,7 @@ import io.quarkus.updates.camel.CamelQuarkusTestUtil;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelJmxTest extends org.apache.camel.updates.camel40.CamelAPIsTest {
+public class CamelJmxTest extends org.apache.camel.upgrade.camel40.CamelAPIsTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelYamlTest.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelYamlTest.java
@@ -4,7 +4,7 @@ import io.quarkus.updates.camel.CamelQuarkusTestUtil;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-public class CamelYamlTest extends org.apache.camel.updates.camel40.CamelYamlTest {
+public class CamelYamlTest extends org.apache.camel.upgrade.camel40.CamelYamlTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -136,7 +136,7 @@
 
 
         <dependency>
-            <groupId>org.apache.camel</groupId>
+            <groupId>org.apache.camel.upgrade</groupId>
             <artifactId>camel-upgrade-recipes</artifactId>
             <version>${camel-upgrade-recipes.version}</version>
         </dependency>

--- a/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3.15.yaml
+++ b/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3.15.yaml
@@ -23,9 +23,12 @@
 #####
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: io.quarkus.updates.camel.camel44.CamelQuarkusMigrationRecipe
-displayName: Migrates `camel 4.0` application to `camel 4.4`
-description: Migrates `camel 4.0` quarkus application to `camel 4.4`.
+name: io.quarkus.updates.camel.camel47.CamelQuarkusMigrationRecipe
+displayName: Migrates `camel 4.4` application to `camel 4.8`
+description: Migrates `camel 4.4` quarkus application to `camel 4.8`.
 recipeList:
-#  use the recipe from camel standalone migration
-  - org.apache.camel.upgrade.camel44.CamelMigrationRecipe
+#  use the recipe from camel upgrade recipes project
+  - org.apache.camel.upgrade.camel45.CamelMigrationRecipe
+  - org.apache.camel.upgrade.camel46.CamelMigrationRecipe
+  - org.apache.camel.upgrade.camel47.CamelMigrationRecipe
+# there is no recipe for camel 4.8 - intentionaly

--- a/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3alpha.yaml
+++ b/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3alpha.yaml
@@ -36,7 +36,7 @@ displayName: Migrate `camel3` application to `camel4.`
 description: Migrate `camel3` quarkus application to `camel4` quarkus.
 recipeList:
   #  use the recipe from camel standalone migration
-  - org.apache.camel.updates.camel40.CamelMigrationRecipe
+  - org.apache.camel.upgrade.camel40.CamelMigrationRecipe
   #  workaround for https://issues.apache.org/jira/browse/CAMEL-21131
   - org.openrewrite.java.camel.migrate.ChangePropertyValue
 ---


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus-updates/issues/219

Upgrade of camel-upgrade-recipes 4.8.0

(with staging repository, therefore this is a draft)

- new recipes for migration to Camel 4.5-4.8 are added
- few test method had to be modified to make sense in Quarkus
- package  used in camel-upgrade-recipes was slightly changed