### PR TITLE
Update 3.0.yaml to use `newArtifactId:` instead of deprecated `newArtifact:`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
         <!-- Make sure all these versions are aligned and use a compatible OpenRewrite version -->
         <!-- The rewrite-recipe-bom release notes should contain the Maven and Gradle plugin versions to target -->
         <!-- https://central.sonatype.com/artifact/org.openrewrite.recipe/rewrite-recipe-bom/versions -->
-        <rewrite-recipe-bom.version>2.17.0</rewrite-recipe-bom.version>
+        <rewrite-recipe-bom.version>2.23.1</rewrite-recipe-bom.version>
         <!--   https://central.sonatype.com/artifact/org.openrewrite.maven/rewrite-maven-plugin/versions -->
-        <rewrite-maven-plugin.version>5.39.0</rewrite-maven-plugin.version>
+        <rewrite-maven-plugin.version>5.47.0</rewrite-maven-plugin.version>
         <!--   https://plugins.gradle.org/plugin/org.openrewrite.rewrite -->
-        <rewrite-gradle-plugin.version>6.18.0</rewrite-gradle-plugin.version>
+        <rewrite-gradle-plugin.version>6.29.0</rewrite-gradle-plugin.version>
         <!-- https://github.com/apache/camel-upgrade-recipes -->
         <camel-upgrade-recipes.version>4.8.0</camel-upgrade-recipes.version>
         <!-- align with https://central.sonatype.com/artifact/org.openrewrite/rewrite-core -->

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelPomRecipeTest.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/camel40/CamelPomRecipeTest.java
@@ -146,7 +146,7 @@ public class CamelPomRecipeTest implements RewriteTest {
                            </dependencies>
 
                         </project>
-                                                        """,
+                        """,
                 """
                         <project>
                            <modelVersion>4.0.0</modelVersion>
@@ -176,14 +176,10 @@ public class CamelPomRecipeTest implements RewriteTest {
                                    <groupId>org.apache.camel.quarkus</groupId>
                                    <artifactId>camel-quarkus-bean</artifactId>
                                </dependency>
-                               <!--<dependency>  org.openrewrite.maven.MavenDownloadingException: org.iota:java-md-doclet:2.2 failed. Unable to download POM. Tried repositories:
-                                   <groupId>org.apache.camel.quarkus</groupId>
-                                   <artifactId>camel-quarkus-iota</artifactId>
-                               </dependency>-->
                            </dependencies>
 
                         </project>
-                                                        """));
+                        """));
     }
 
     @Test

--- a/recipes/src/main/java/io/quarkus/updates/core/quarkus310/AdjustPackageProperty.java
+++ b/recipes/src/main/java/io/quarkus/updates/core/quarkus310/AdjustPackageProperty.java
@@ -73,9 +73,10 @@ public class AdjustPackageProperty extends Recipe {
                 Xml.Tag propertiesTag = (Xml.Tag) super.visitTag(tag, ctx);
 
                 if (PROPERTIES.equals(propertiesTag.getName())) {
-                    Optional<Xml.Tag> packageType = propertiesTag.getChild(QUARKUS_PACKAGE_TYPE);
-                    if (packageType.isPresent()) {
-                        Optional<String> packageTypeValue = packageType.get().getValue();
+                    Optional<Xml.Tag> packageTypeOptional = propertiesTag.getChild(QUARKUS_PACKAGE_TYPE);
+                    if (packageTypeOptional.isPresent()) {
+                        Xml.Tag packageType = packageTypeOptional.get();
+                        Optional<String> packageTypeValue = packageType.getValue();
                         if (packageTypeValue.isPresent()) {
                             switch (packageTypeValue.get()) {
                                 case JAR:
@@ -83,18 +84,18 @@ public class AdjustPackageProperty extends Recipe {
                                 case FAST_JAR:
                                 case MUTABLE_JAR:
                                     propertiesTag = addToTag(propertiesTag, Xml.Tag.build("<" + QUARKUS_PACKAGE_JAR_TYPE + ">" + packageTypeValue.get() + "</" + QUARKUS_PACKAGE_JAR_TYPE + ">"), getCursor().getParentOrThrow());
-                                    doAfterVisit(new RemoveContentVisitor<>(packageType.get(), false));
+                                    doAfterVisit(new RemoveContentVisitor<>(packageType, false, false));
                                     break;
                                 case NATIVE:
                                     propertiesTag = addToTag(propertiesTag, Xml.Tag.build("<"+ QUARKUS_NATIVE_ENABLED +">true</" + QUARKUS_NATIVE_ENABLED + ">"), getCursor().getParentOrThrow());
                                     propertiesTag = addToTag(propertiesTag, Xml.Tag.build("<"+ QUARKUS_PACKAGE_JAR_ENABLED +">false</" + QUARKUS_PACKAGE_JAR_ENABLED + ">"), getCursor().getParentOrThrow());
-                                    doAfterVisit(new RemoveContentVisitor<>(packageType.get(), false));
+                                    doAfterVisit(new RemoveContentVisitor<>(packageType, false, false));
                                     break;
                                 case NATIVE_SOURCES:
                                     propertiesTag = addToTag(propertiesTag, Xml.Tag.build("<"+ QUARKUS_NATIVE_ENABLED +">true</" + QUARKUS_NATIVE_ENABLED + ">"), getCursor().getParentOrThrow());
                                     propertiesTag = addToTag(propertiesTag, Xml.Tag.build("<"+ QUARKUS_NATIVE_SOURCES_ONLY +">true</" + QUARKUS_NATIVE_SOURCES_ONLY + ">"), getCursor().getParentOrThrow());
                                     propertiesTag = addToTag(propertiesTag, Xml.Tag.build("<"+ QUARKUS_PACKAGE_JAR_ENABLED +">false</" + QUARKUS_PACKAGE_JAR_ENABLED + ">"), getCursor().getParentOrThrow());
-                                    doAfterVisit(new RemoveContentVisitor<>(packageType.get(), false));
+                                    doAfterVisit(new RemoveContentVisitor<>(packageType, false, false));
                                     break;
                                 default:
                                     // do nothing for legacy jars

--- a/recipes/src/main/java/io/quarkus/updates/core/quarkus37/ChangeMavenCompilerAnnotationProcessorGroupIdAndArtifactId.java
+++ b/recipes/src/main/java/io/quarkus/updates/core/quarkus37/ChangeMavenCompilerAnnotationProcessorGroupIdAndArtifactId.java
@@ -162,7 +162,7 @@ public class ChangeMavenCompilerAnnotationProcessorGroupIdAndArtifactId extends 
                                             //If the previous dependency had a version but the new artifact is managed, removed the
                                             //version tag.
                                             mavenCompilerPluginTag = (Xml.Tag) new RemoveContentVisitor<>(versionTag.get(),
-                                                    false).visit(mavenCompilerPluginTag, ctx);
+                                                    false, false).visit(mavenCompilerPluginTag, ctx);
                                         } else {
                                             //Otherwise, change the version to the new value.
                                             mavenCompilerPluginTag = changeChildTagValue(mavenCompilerPluginTag, annotationProcessorPath,

--- a/recipes/src/main/resources/quarkus-updates/core/3.0.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.0.yaml
@@ -1106,7 +1106,7 @@ recipeList:
       oldGroupId: io.quarkus
       oldArtifactId: quarkus-bootstrap-maven-plugin
       newGroupId: io.quarkus
-      newArtifact: quarkus-extension-maven-plugin
+      newArtifactId: quarkus-extension-maven-plugin
 
 #####
 # Additional recipes for Kotlin

--- a/recipes/src/main/resources/quarkus-updates/core/3.7.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.7.alpha1.yaml
@@ -139,9 +139,9 @@ tags:
 recipeList:
   - org.openrewrite.github.SetupJavaUpgradeJavaVersion:
       minimumJavaMajorVersion: 17
-  - org.openrewrite.java.migrate.RemoveMethodInvocation:
+  - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.lang.Runtime traceInstructions(boolean)
-  - org.openrewrite.java.migrate.RemoveMethodInvocation:
+  - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.lang.System traceMethodCalls(boolean)
   - org.openrewrite.maven.UpgradePluginVersion:
       groupId: org.apache.maven.plugins


### PR DESCRIPTION
Following on from 
- https://github.com/openrewrite/rewrite/pull/3843
- https://github.com/openrewrite/rewrite/pull/4421

And especially relevant now with
- https://github.com/openrewrite/rewrite/issues/4902

- Fixes #226