### PR TITLE
Rewrite recipe bom 3.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,5 +57,5 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -B clean install -Dno-format
+        run: mvn -B clean install -Dno-format -Dstyle.color=always
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,5 +57,5 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn -B clean install -Dno-format -Dstyle.color=always
+        run: mvn --batch-mode --no-transfer-progress clean install -Dno-format -Dstyle.color=always
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
         <!-- Make sure all these versions are aligned and use a compatible OpenRewrite version -->
         <!-- The rewrite-recipe-bom release notes should contain the Maven and Gradle plugin versions to target -->
         <!-- https://central.sonatype.com/artifact/org.openrewrite.recipe/rewrite-recipe-bom/versions -->
-        <rewrite-recipe-bom.version>2.23.1</rewrite-recipe-bom.version>
+        <rewrite-recipe-bom.version>3.0.2</rewrite-recipe-bom.version>
         <!--   https://central.sonatype.com/artifact/org.openrewrite.maven/rewrite-maven-plugin/versions -->
-        <rewrite-maven-plugin.version>5.47.0</rewrite-maven-plugin.version>
+        <rewrite-maven-plugin.version>6.0.4</rewrite-maven-plugin.version>
         <!--   https://plugins.gradle.org/plugin/org.openrewrite.rewrite -->
-        <rewrite-gradle-plugin.version>6.29.0</rewrite-gradle-plugin.version>
+        <rewrite-gradle-plugin.version>7.0.3</rewrite-gradle-plugin.version>
         <!-- https://github.com/apache/camel-upgrade-recipes -->
         <camel-upgrade-recipes.version>4.8.0</camel-upgrade-recipes.version>
         <!-- align with https://central.sonatype.com/artifact/org.openrewrite/rewrite-core -->
@@ -75,7 +75,7 @@
         <!-- Http version used by the tests -->
         <http.version>4.5.14</http.version>
 
-        <lombok.version>1.18.34</lombok.version>
+        <lombok.version>1.18.36</lombok.version>
         <slf4j.version>1.7.36</slf4j.version>
 
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -60,11 +60,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-21</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <!-- TODO Remove dependency -->
             <groupId>org.openrewrite.recipe</groupId>
             <artifactId>rewrite-migrate-java</artifactId>
         </dependency>

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -72,6 +72,12 @@
         <dependency>
             <groupId>org.openrewrite.recipe</groupId>
             <artifactId>rewrite-quarkus</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.openrewrite.recipe</groupId>
+                    <artifactId>rewrite-migrate-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- rewrite-gradle dependency only necessary for Gradle Recipe development -->
@@ -147,6 +153,12 @@
             <groupId>org.apache.camel.upgrade</groupId>
             <artifactId>camel-upgrade-recipes</artifactId>
             <version>${camel-upgrade-recipes.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.openrewrite.recipe</groupId>
+                    <artifactId>rewrite-migrate-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -70,13 +70,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <!-- TODO Remove dependency -->
-            <groupId>org.openrewrite.recipe</groupId>
-            <artifactId>rewrite-migrate-java</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.openrewrite.recipe</groupId>
             <artifactId>rewrite-quarkus</artifactId>
+        </dependency>
+
+        <!-- rewrite-gradle dependency only necessary for Gradle Recipe development -->
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-gradle</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- rewrite-maven dependency only necessary for Maven Recipe development -->

--- a/recipes/src/main/java/io/quarkus/updates/core/quarkus37/SetupJavaUpgradeJavaVersion.java
+++ b/recipes/src/main/java/io/quarkus/updates/core/quarkus37/SetupJavaUpgradeJavaVersion.java
@@ -1,0 +1,74 @@
+package io.quarkus.updates.core.quarkus37;
+
+import org.openrewrite.*;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.YamlVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class SetupJavaUpgradeJavaVersion extends Recipe {
+
+    @Option(displayName = "Java version",
+            description = "The Java version to upgrade to.",
+            example = "17")
+    Integer minimumJavaMajorVersion;
+
+    @Override
+    public String getDisplayName() {
+        return "Upgrade `actions/setup-java` `java-version`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Update the Java version used by `actions/setup-java` if it is below the expected version number.";
+    }
+
+    private static final JsonPathMatcher javaVersion = new JsonPathMatcher("..steps[?(@.uses =~ 'actions/setup-java@v*.*')].with.java-version");
+    private static final Pattern javaVersionPattern = Pattern.compile("([0-9]+)(\\.[0-9]+)*([-+].*)?");
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new FindSourceFiles(".github/workflows/*.yml"),
+                new YamlVisitor<>() {
+                    @Override
+                    public Yaml visitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                        if (!javaVersion.matches(getCursor())) {
+                            return super.visitMappingEntry(entry, ctx);
+                        }
+
+                        Yaml.Scalar currentValue = (Yaml.Scalar) entry.getValue();
+
+                        // specific versions are allowed by `actions/setup-java`
+                        Matcher matcher = javaVersionPattern.matcher(currentValue.getValue());
+                        if (!matcher.matches()) {
+                            return super.visitMappingEntry(entry, ctx);
+                        }
+
+                        int currentMajorVersion;
+                        try {
+                            currentMajorVersion = Integer.parseInt(matcher.group(1));
+                        } catch (NumberFormatException ex) {
+                            return super.visitMappingEntry(entry, ctx);
+                        }
+
+                        if (currentMajorVersion >= minimumJavaMajorVersion) {
+                            return super.visitMappingEntry(entry, ctx);
+                        }
+
+                        return super.visitMappingEntry(
+                                entry.withValue(currentValue.withValue(String.valueOf(minimumJavaMajorVersion))),
+                                ctx
+                        );
+                    }
+                });
+    }
+
+}

--- a/recipes/src/main/java/io/quarkus/updates/core/quarkus37/UpgradeJavaVersion.java
+++ b/recipes/src/main/java/io/quarkus/updates/core/quarkus37/UpgradeJavaVersion.java
@@ -1,0 +1,76 @@
+package io.quarkus.updates.core.quarkus37;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.gradle.UpdateJavaCompatibility;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.marker.JavaVersion;
+import org.openrewrite.maven.UpdateMavenProjectPropertyJavaVersion;
+import org.openrewrite.maven.UseMavenCompilerPluginReleaseConfiguration;
+import org.openrewrite.java.tree.J;
+
+import java.time.Duration;
+import java.util.*;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class UpgradeJavaVersion extends Recipe {
+
+    @Option(displayName = "Java version",
+            description = "The Java version to upgrade to.",
+            example = "17")
+    Integer version;
+
+    @Override
+    public String getDisplayName() {
+        return "Upgrade Java version";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Upgrade build plugin configuration to use the specified Java version. " +
+               "This recipe changes `java.toolchain.languageVersion` in `build.gradle(.kts)` of gradle projects, " +
+               "or maven-compiler-plugin target version and related settings. " +
+               "Will not downgrade if the version is newer than the specified version.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        return Arrays.asList(
+                new UseMavenCompilerPluginReleaseConfiguration(version),
+                new UpdateMavenProjectPropertyJavaVersion(version),
+                new UpdateJavaCompatibility(version, null, null, false, null)
+        );
+    }
+
+    /**
+     * This recipe only updates markers, so it does not correspond to human manual effort.
+     *
+     * @return Zero estimated time.
+     */
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(0);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        String newVersion = version.toString();
+        Map<JavaVersion, JavaVersion> updatedMarkers = new HashMap<>();
+        return new JavaIsoVisitor<>() {
+            @Override
+            public J preVisit(J tree, ExecutionContext ctx) {
+                Optional<JavaVersion> maybeJavaVersion = tree.getMarkers().findFirst(JavaVersion.class);
+                if (maybeJavaVersion.isPresent() && maybeJavaVersion.get().getMajorVersion() < version) {
+                    return tree.withMarkers(tree.getMarkers().setByType(updatedMarkers.computeIfAbsent(maybeJavaVersion.get(),
+                            m -> m.withSourceCompatibility(newVersion).withTargetCompatibility(newVersion))));
+                }
+                return tree;
+            }
+        };
+    }
+}

--- a/recipes/src/main/resources/quarkus-updates/core/3.7.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.7.alpha1.yaml
@@ -137,7 +137,7 @@ description: >
 tags:
   - java17
 recipeList:
-  - org.openrewrite.github.SetupJavaUpgradeJavaVersion: # TODO Fork recipe or remove
+  - io.quarkus.updates.core.quarkus37.SetupJavaUpgradeJavaVersion:
       minimumJavaMajorVersion: 17
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.lang.Runtime traceInstructions(boolean)
@@ -150,13 +150,13 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus37.JavaVersion17
-displayName: Change Maven Java version property values to 17
+displayName: Change Maven and Gradle Java version property values to 17
 description: Change maven.compiler.source and maven.compiler.target values to 17.
 tags:
   - java17
   - compiler
 recipeList:
-  - org.openrewrite.java.migrate.UpgradeJavaVersion: # TODO Fork recipe or remove
+  - io.quarkus.updates.core.quarkus37.UpgradeJavaVersion:
       version: 17
   - org.openrewrite.maven.UseMavenCompilerPluginReleaseConfiguration:
       releaseVersion: 17

--- a/recipes/src/main/resources/quarkus-updates/core/3.7.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.7.alpha1.yaml
@@ -137,7 +137,7 @@ description: >
 tags:
   - java17
 recipeList:
-  - org.openrewrite.github.SetupJavaUpgradeJavaVersion:
+  - org.openrewrite.github.SetupJavaUpgradeJavaVersion: # TODO Fork recipe or remove
       minimumJavaMajorVersion: 17
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: java.lang.Runtime traceInstructions(boolean)
@@ -156,9 +156,9 @@ tags:
   - java17
   - compiler
 recipeList:
-  - org.openrewrite.java.migrate.UpgradeJavaVersion:
+  - org.openrewrite.java.migrate.UpgradeJavaVersion: # TODO Fork recipe or remove
       version: 17
-  - org.openrewrite.java.migrate.maven.UseMavenCompilerPluginReleaseConfiguration:
+  - org.openrewrite.maven.UseMavenCompilerPluginReleaseConfiguration:
       releaseVersion: 17
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -179,7 +179,7 @@ description: The `com.sun.net.ssl.internal.ssl.Provider` provider name was remov
 tags:
   - java17
 recipeList:
-  - org.openrewrite.java.migrate.ReplaceStringLiteralValue:
+  - org.openrewrite.java.ReplaceStringLiteralValue:
       oldLiteralValue: com.sun.net.ssl.internal.ssl.Provider
       newLiteralValue: SunJSSE
 ---
@@ -193,7 +193,7 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: java.util.logging.LogRecord getThreadID()
       newMethodName: getLongThreadID
-  - org.openrewrite.java.migrate.ChangeMethodInvocationReturnType:
+  - org.openrewrite.java.ChangeMethodInvocationReturnType:
       methodPattern: java.util.logging.LogRecord getLongThreadID()
       newReturnType: long
   - org.openrewrite.java.ChangeMethodName:


### PR DESCRIPTION
Work in progress, as discussed after
- https://github.com/quarkusio/quarkus-updates/pull/236

/cc @gsmet to avoid duplicate work or conflicts

My process for these changes was to look at these specific Apache licensed versions of the recipes
- https://github.com/openrewrite/rewrite-migrate-java/blob/v2.30.1/src/main/java/org/openrewrite/java/migrate/UpgradeJavaVersion.java
- https://github.com/openrewrite/rewrite-github-actions/blob/v2.10.1/src/main/java/org/openrewrite/github/SetupJavaUpgradeJavaVersion.java

Then from there modify them to strip out the call out to modify Jenkins build files for instance, simplify them where arguments are concerned, inline static nested class, and add the result here.