### PR TITLE
Add recipe for Quarkus 3.19 that moves OIDC Token Propagation annotation @AccessToken to a new package

### DIFF
--- a/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate319Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate319Test.java
@@ -1,0 +1,89 @@
+package io.quarkus.updates.core;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import java.nio.file.Path;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class CoreUpdate319Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        @Language("java")
+        String accessTokenAnnotation = """
+                package io.quarkus.oidc.token.propagation;
+                                        
+                import java.lang.annotation.Documented;
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+                import java.lang.annotation.Target;
+                
+                @Target({ ElementType.TYPE })
+                @Retention(RetentionPolicy.RUNTIME)
+                @Documented
+                public @interface AccessToken {
+                    String exchangeTokenClient() default "";
+                }
+                """;
+        CoreTestUtil.recipe(spec, Path.of("quarkus-updates", "core", "3.19.alpha1.yaml"), "3.19.0")
+                .parser(JavaParser.fromJavaVersion()
+                                .dependsOn(accessTokenAnnotation)
+                        .logCompilationWarningsAndErrors(true))
+                .typeValidationOptions(TypeValidation.all());
+    }
+
+    @Test
+    void testAccessTokenAnnotationMovedToNewPackage() {
+        //language=java
+        rewriteRun(java(
+                """
+                package io.quarkus.it.keycloak;
+                
+                import io.quarkus.oidc.token.propagation.AccessToken;
+                
+                @AccessToken
+                public interface AccessTokenPropagationService {
+                    String getUserName();
+                }
+                """,
+                """
+                package io.quarkus.it.keycloak;
+                
+                import io.quarkus.oidc.token.propagation.common.AccessToken;
+                
+                @AccessToken
+                public interface AccessTokenPropagationService {
+                    String getUserName();
+                }
+                """));
+        //language=java
+        rewriteRun(java(
+                """
+                package io.quarkus.it.keycloak;
+                
+                import io.quarkus.oidc.token.propagation.AccessToken;
+                
+                @AccessToken(exchangeTokenClient = "Default")
+                public interface AccessTokenPropagationService {
+                    String getUserName();
+                }
+                """,
+                """
+                package io.quarkus.it.keycloak;
+                
+                import io.quarkus.oidc.token.propagation.common.AccessToken;
+                
+                @AccessToken(exchangeTokenClient = "Default")
+                public interface AccessTokenPropagationService {
+                    String getUserName();
+                }
+                """));
+    }
+}

--- a/recipes/src/main/resources/quarkus-updates/core/3.19.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.19.alpha1.yaml
@@ -1,0 +1,10 @@
+#####
+# Move OIDC Token Propagation annotation '@AccessToken' to a new package
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus319.MoveAccessTokenAnnotationToNewPackage
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.quarkus.oidc.token.propagation.AccessToken
+      newFullyQualifiedTypeName: io.quarkus.oidc.token.propagation.common.AccessToken


### PR DESCRIPTION
Adds a recipe for changes made in https://github.com/quarkusio/quarkus/pull/45923.