### PR TITLE
Correlate Camel Quarkus recipes and tests versions and update to 4.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!--   https://plugins.gradle.org/plugin/org.openrewrite.rewrite -->
         <rewrite-gradle-plugin.version>7.0.3</rewrite-gradle-plugin.version>
         <!-- https://github.com/apache/camel-upgrade-recipes -->
-        <camel-upgrade-recipes.version>4.8.0</camel-upgrade-recipes.version>
+        <camel-upgrade-recipes.version>4.9.0</camel-upgrade-recipes.version>
         <!-- align with https://central.sonatype.com/artifact/org.openrewrite/rewrite-core -->
         <micrometer-core.version>1.9.17</micrometer-core.version>
         <!-- tests-->

--- a/recipes-tests/pom.xml
+++ b/recipes-tests/pom.xml
@@ -28,11 +28,11 @@
         <rewrite-tmp-classpath>${project.build.testOutputDirectory}/META-INF/rewrite/classpath</rewrite-tmp-classpath>
 
         <!-- Versions of the camel dependencies used by camel-quarkus 3.0 and 3.8 -->
-        <test.camel-quarkus-3-0.camel-version>3.18.6</test.camel-quarkus-3-0.camel-version>
+        <test.camel-quarkus-3-0.camel-version>${camel-upgrade-recipes.version}</test.camel-quarkus-3-0.camel-version>
         <test.camel-quarkus-3-0.http-client-version>4.5.14</test.camel-quarkus-3-0.http-client-version>
         <test.camel-quarkus-3-0.http-core-version>4.4.16</test.camel-quarkus-3-0.http-core-version>
-        <test.camel-quarkus-3-8.camel-version>4.0.3</test.camel-quarkus-3-8.camel-version>
-        <test.camel-quarkus-3-15.camel-version>4.8.0</test.camel-quarkus-3-15.camel-version>
+        <test.camel-quarkus-3-8.camel-version>${camel-upgrade-recipes.version}</test.camel-quarkus-3-8.camel-version>
+        <test.camel-quarkus-3-15.camel-version>${camel-upgrade-recipes.version}</test.camel-quarkus-3-15.camel-version>
         <test.camel-quarkus-3-15.jakarta-servlet-api-version>6.0.0</test.camel-quarkus-3-15.jakarta-servlet-api-version>
 
     </properties>


### PR DESCRIPTION
And update to 4.9.0.

I tried to update everything consistently but I still have the same error:

```
Unable to find classpath resource dependencies beginning with: 'jakarta.inject-api-2.0.0'.
The caller is of type org.apache.camel.upgrade.CamelTestUtil.
```

And some others probably due to the fact we updated OpenRewrite.

It will definitely need more work.

```
[ERROR] io.quarkus.updates.camel.camel40.CamelAPIsPropertiesTest.testRejectedPolicyDiscard -- Time elapsed: 0.285 s <<< FAILURE!
java.lang.AssertionError: 
[Recipe validation must have no failures] 
Expecting empty but was: [[Valid{property='CompositeRecipe.recipeList', value='[org.openrewrite.config.DeclarativeRecipe@905d26e3]'},
    Invalid{property='initialization', value='[org.openrewrite.config.DeclarativeRecipe@1145a741]', message='DeclarativeRecipe must not contain uninitialized recipes. Be sure to call .initialize() on DeclarativeRecipe.'},
    Invalid{property='io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe.recipeList[1] (in rewrite.yml)', value='org.openrewrite.java.camel.migrate.ChangePropertyValue', message='recipe 'org.openrewrite.java.camel.migrate.ChangePropertyValue' does not exist.'},
    Invalid{property='initialization', value='[org.openrewrite.config.DeclarativeRecipe@1145a741]', message='DeclarativeRecipe must not contain uninitialized recipes. Be sure to call .initialize() on DeclarativeRecipe.'},
    Invalid{property='io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe.recipeList[1] (in rewrite.yml)', value='org.openrewrite.java.camel.migrate.ChangePropertyValue', message='recipe 'org.openrewrite.java.camel.migrate.ChangePropertyValue' does not exist.'},
    Valid{property='ChangePropertyValue.newValue', value='Abort #DiscardOldest has been removed, consider Abort'},
    Valid{property='ChangePropertyValue.propertyKey', value='camel.threadpool.rejectedPolicy'},
    Valid{property='oldValue', value='DiscardOldest'},
    Valid{property='ChangePropertyValue.newValue', value='Abort #Discard has been removed, consider Abort'},
    Valid{property='ChangePropertyValue.propertyKey', value='camel.threadpool.rejectedPolicy'},
    Valid{property='oldValue', value='Discard'},
    Valid{property='MoveGetterToPluginHelper.oldMethodName', value='getComponentNameResolver'},
    Valid{property='MoveGetterToPluginHelper.oldMethodName', value='getModelJAXBContextFactory'},
    Valid{property='MoveGetterToPluginHelper.oldMethodName', value='getModelToXMLDumper'},
    Valid{property='MoveGetterToPluginHelper.oldMethodName', value='getRoutesLoader'},
    Valid{property='ChangeType.newFullyQualifiedTypeName', value='org.apache.camel.impl.engine.IntrospectionSupport'},
    Valid{property='ChangeType.oldFullyQualifiedTypeName', value='org.apache.camel.support.IntrospectionSupport'},
    Valid{property='ChangeMethodName.methodPattern', value='org.apache.camel.api.management.mbean.ManagedChoiceMBean choiceStatistics()'},
    Valid{property='ChangeMethodName.newMethodName', value='extendedInformation'},
    Valid{property='ChangeMethodName.methodPattern', value='org.apache.camel.api.management.mbean.ManagedFailoverLoadBalancerMBean exceptionStatistics()'},
    Valid{property='ChangeMethodName.newMethodName', value='extendedInformation'}],
    [Invalid{property='initialization', value='[org.openrewrite.config.DeclarativeRecipe@1145a741]', message='DeclarativeRecipe must not contain uninitialized recipes. Be sure to call .initialize() on DeclarativeRecipe.'},
    Invalid{property='io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe.recipeList[1] (in rewrite.yml)', value='org.openrewrite.java.camel.migrate.ChangePropertyValue', message='recipe 'org.openrewrite.java.camel.migrate.ChangePropertyValue' does not exist.'},
    Valid{property='ChangePropertyValue.newValue', value='Abort #DiscardOldest has been removed, consider Abort'},
    Valid{property='ChangePropertyValue.propertyKey', value='camel.threadpool.rejectedPolicy'},
    Valid{property='oldValue', value='DiscardOldest'},
    Valid{property='ChangePropertyValue.newValue', value='Abort #Discard has been removed, consider Abort'},
    Valid{property='ChangePropertyValue.propertyKey', value='camel.threadpool.rejectedPolicy'},
    Valid{property='oldValue', value='Discard'},
    Valid{property='MoveGetterToPluginHelper.oldMethodName', value='getComponentNameResolver'},
    Valid{property='MoveGetterToPluginHelper.oldMethodName', value='getModelJAXBContextFactory'},
    Valid{property='MoveGetterToPluginHelper.oldMethodName', value='getModelToXMLDumper'},
    Valid{property='MoveGetterToPluginHelper.oldMethodName', value='getRoutesLoader'},
    Valid{property='ChangeType.newFullyQualifiedTypeName', value='org.apache.camel.impl.engine.IntrospectionSupport'},
    Valid{property='ChangeType.oldFullyQualifiedTypeName', value='org.apache.camel.support.IntrospectionSupport'},
    Valid{property='ChangeMethodName.methodPattern', value='org.apache.camel.api.management.mbean.ManagedChoiceMBean choiceStatistics()'},
    Valid{property='ChangeMethodName.newMethodName', value='extendedInformation'},
    Valid{property='ChangeMethodName.methodPattern', value='org.apache.camel.api.management.mbean.ManagedFailoverLoadBalancerMBean exceptionStatistics()'},
    Valid{property='ChangeMethodName.newMethodName', value='extendedInformation'}]]
	at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:220)
	at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:129)
	at org.openrewrite.test.RewriteTest.rewriteRun(RewriteTest.java:124)
	at org.apache.camel.upgrade.camel40.CamelAPIsPropertiesTest.testRejectedPolicyDiscard(CamelAPIsPropertiesTest.java:50)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```