### PR TITLE
Bumped camel-upgrade-recipes to 4.9.0 & migration to CQ 3.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!--   https://plugins.gradle.org/plugin/org.openrewrite.rewrite -->
         <rewrite-gradle-plugin.version>7.0.3</rewrite-gradle-plugin.version>
         <!-- https://github.com/apache/camel-upgrade-recipes -->
-        <camel-upgrade-recipes.version>4.8.0</camel-upgrade-recipes.version>
+        <camel-upgrade-recipes.version>4.9.0</camel-upgrade-recipes.version>
         <!-- align with https://central.sonatype.com/artifact/org.openrewrite/rewrite-core -->
         <micrometer-core.version>1.9.17</micrometer-core.version>
         <!-- tests-->

--- a/recipes-tests/pom.xml
+++ b/recipes-tests/pom.xml
@@ -34,6 +34,7 @@
         <test.camel-quarkus-3-8.camel-version>4.0.3</test.camel-quarkus-3-8.camel-version>
         <test.camel-quarkus-3-15.camel-version>4.8.0</test.camel-quarkus-3-15.camel-version>
         <test.camel-quarkus-3-15.jakarta-servlet-api-version>6.0.0</test.camel-quarkus-3-15.jakarta-servlet-api-version>
+        <test.camel-quarkus-3-17.camel-version>4.9.0</test.camel-quarkus-3-17.camel-version>
 
     </properties>
 
@@ -408,6 +409,74 @@
                                     <groupId>jakarta.servlet</groupId>
                                     <artifactId>jakarta.servlet-api</artifactId>
                                     <version>${test.camel-quarkus-3-15.jakarta-servlet-api-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <!-- camel quarkus 3.17 (camel 4.9.0) test dependencies-->
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-api</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-db2</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-mongodb</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-oracle</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-mysql</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-postgres</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-sqlserver</artifactId>
+                                    <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+
+                                <artifactItem>
+                                    <groupId>jakarta.xml.bind</groupId>
+                                    <artifactId>jakarta.xml.bind-api</artifactId>
+                                    <version>4.0.2</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.inject</groupId>
+                                    <artifactId>jakarta.inject-api</artifactId>
+                                    <version>2.0.0</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>javax.xml.bind</groupId>
+                                    <artifactId>jaxb-api</artifactId>
+                                    <version>2.3.1</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.ws.rs</groupId>
+                                    <artifactId>jakarta.ws.rs-api</artifactId>
+                                    <version>3.1.0</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelQuarkusTestUtil.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelQuarkusTestUtil.java
@@ -26,6 +26,10 @@ public class CamelQuarkusTestUtil {
         return recipeForVersion("3.15", spec, activeRecipes);
     }
 
+    public static RecipeSpec recipe3_17(RecipeSpec spec, String... activeRecipes) {
+        return recipeForVersion("3.17", spec, activeRecipes);
+    }
+
     private static RecipeSpec recipeForVersion(String version, RecipeSpec spec, String... activeRecipes) {
         if(activeRecipes.length == 0) {
             return recipe(spec, version);
@@ -40,6 +44,7 @@ public class CamelQuarkusTestUtil {
             case "3.8" -> new String[] {"io.quarkus.updates.camel.camel44.CamelQuarkusMigrationRecipe"};
             case "3alpha" -> new String[] {"io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe"};
             case "3.15" -> new String[] {"io.quarkus.updates.camel.camel47.CamelQuarkusMigrationRecipe"};
+            case "3.17" -> new String[] {"io.quarkus.updates.camel.camel49.CamelQuarkusMigrationRecipe"};
             default -> throw new IllegalArgumentException("Version '" + version + "' is not allowed!");
         };
         return recipe(spec, version, defaultRecipes);

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate49Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate49Test.java
@@ -1,0 +1,109 @@
+package io.quarkus.updates.camel;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class CamelUpdate49Test extends org.apache.camel.upgrade.CamelUpdate49Test {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        //let the parser be initialized in the camel parent
+        super.defaults(spec);
+        //recipe has to be loaded differently
+        CamelQuarkusTestUtil.recipe3_17(spec)
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    /**
+     * Quarkus-updates recipes somehow groups imports in comparison to camel-upgrade-recipes.
+     * (The original test method contains a lot of imports which are grouped in the result)
+     * Therefore, I override this test method to avoid grouping behavior.
+     * According to the doc, it should b possible to declar import style, see https://docs.openrewrite.org/reference/yaml-format-reference#style-example
+     *
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_debezium">camel-debezium</a>
+     */
+    @Test
+    @Override
+    public void testDebezium() {
+        //language=java
+        rewriteRun(java(
+                """
+                        import org.apache.camel.component.debezium.configuration.Db2ConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.configuration.MongodbConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumMongodbComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumMongodbComponent;
+                        import org.apache.camel.component.debezium.configuration.MySqlConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumMySqlComponent;
+                        import org.apache.camel.component.debezium.configuration.OracleConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumOracleComponent;
+                        import org.apache.camel.component.debezium.configuration.PostgresConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumPostgresComponent;
+                        import org.apache.camel.component.debezium.configuration.SqlserverConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumSqlserverComponent;
+                        
+                        public class DebeziumTest {
+    
+                            public void method() {
+                                //db2
+                                Db2ConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumDb2Component component = null;
+                                //mongodb
+                                MongodbConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumMongodbComponent component = null;
+                                //mysql
+                                MySqlConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumMySqlComponent component = null;
+                                //oracle
+                                OracleConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumOracleComponent component = null;
+                                //postgres
+                                PostgresConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumPostgresComponent component = null;
+                                //sqlserver
+                                SqlserverConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumSqlserverComponent component = null;
+                            }
+                        }
+                        """,
+                """
+                        import org.apache.camel.component.debezium.configuration.MongodbConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.configuration.SqlserverConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.db2.configuration.Db2ConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.mongodb.DebeziumMongodbComponent;
+                        import org.apache.camel.component.debezium.mysql.DebeziumMySqlComponent;
+                        import org.apache.camel.component.debezium.mysql.configuration.MySqlConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.oracle.DebeziumOracleComponent;
+                        import org.apache.camel.component.debezium.oracle.configuration.OracleConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.postgres.DebeziumPostgresComponent;
+                        import org.apache.camel.component.debezium.postgres.configuration.PostgresConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.sqlserver.DebeziumSqlserverComponent;
+                         
+                        public class DebeziumTest {
+                        
+                            public void method() {
+                                //db2
+                                Db2ConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumDb2Component component = null;
+                                //mongodb
+                                MongodbConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumMongodbComponent component = null;
+                                //mysql
+                                MySqlConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumMySqlComponent component = null;
+                                //oracle
+                                OracleConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumOracleComponent component = null;
+                                //postgres
+                                PostgresConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumPostgresComponent component = null;
+                                //sqlserver
+                                SqlserverConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumSqlserverComponent component = null;
+                            }
+                        }
+                      """));
+    }
+}

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -162,6 +162,7 @@
         </dependency>
     </dependencies>
 
+
     <build>
         <resources>
             <resource>

--- a/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3.17.yaml
+++ b/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3.17.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2021 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide.html
+#####
+
+#####
+# Update the Camel - Quarkus extensions
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.camel.camel49.CamelQuarkusMigrationRecipe
+displayName: Migrates `camel 4.8` application to `camel 4.9`
+description: Migrates `camel 4.8` quarkus application to `camel 4.9`.
+recipeList:
+#  use the recipe from camel upgrade recipes project
+  - org.apache.camel.upgrade.camel49.CamelMigrationRecipe

--- a/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3alpha.yaml
+++ b/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3alpha.yaml
@@ -37,8 +37,6 @@ description: Migrate `camel3` quarkus application to `camel4` quarkus.
 recipeList:
   #  use the recipe from camel standalone migration
   - org.apache.camel.upgrade.camel40.CamelMigrationRecipe
-  #  workaround for https://issues.apache.org/jira/browse/CAMEL-21131
-  - org.openrewrite.java.camel.migrate.ChangePropertyValue
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.camel.migrate.removedExtensions


### PR DESCRIPTION
Replaces https://github.com/quarkusio/quarkus-updates/pull/249

Camel-upgrade-recipes is updated to to 4.9.0:

- some constants and util classes had to be updated to cover new version
- more jars of the different versions, required to compile tests, are added (i.e. related to https://github.com/apache/camel-upgrade-recipes/commit/bd9c7a92766c542b7006399250ad5d31148eb96e#diff-d90e48a6b59ba036b8a355a209ed46ffe42636ae3dec25c95501d87443ef2c3f)
- I encountered a weird behavior related to import groupings in `CamelUpdate49Test`. As you can see the camel expected test result ([code](https://github.com/apache/camel-upgrade-recipes/blob/main/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate49Test.java#L257-L284)), majority of the import statement stays un-grouped. Whereas in quarkus-updates project, all import statements are replaced by **.*** statements. I shrink the test method, so grouping does not happen (and the test is covering the presence of the recipe). I also put a comment to the method, because grouping of the import statements should be configurable.