### PR TITLE
Bump camel-upgrade-recipes to 4.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!--   https://plugins.gradle.org/plugin/org.openrewrite.rewrite -->
         <rewrite-gradle-plugin.version>7.0.3</rewrite-gradle-plugin.version>
         <!-- https://github.com/apache/camel-upgrade-recipes -->
-        <camel-upgrade-recipes.version>4.9.0</camel-upgrade-recipes.version>
+        <camel-upgrade-recipes.version>4.10.0</camel-upgrade-recipes.version>
         <!-- align with https://central.sonatype.com/artifact/org.openrewrite/rewrite-core -->
         <micrometer-core.version>1.9.17</micrometer-core.version>
         <!-- tests-->

--- a/recipes-tests/pom.xml
+++ b/recipes-tests/pom.xml
@@ -35,6 +35,7 @@
         <test.camel-quarkus-3-15.camel-version>4.8.0</test.camel-quarkus-3-15.camel-version>
         <test.camel-quarkus-3-15.jakarta-servlet-api-version>6.0.0</test.camel-quarkus-3-15.jakarta-servlet-api-version>
         <test.camel-quarkus-3-17.camel-version>4.9.0</test.camel-quarkus-3-17.camel-version>
+        <test.camel-quarkus-3-18.camel-version>4.10.0</test.camel-quarkus-3-18.camel-version>
 
     </properties>
 
@@ -452,6 +453,19 @@
                                     <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-debezium-sqlserver</artifactId>
                                     <version>${test.camel-quarkus-3-15.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <!-- camel quarkus 3.18 (camel 4.10.0) test dependencies-->
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-smb</artifactId>
+                                    <version>${test.camel-quarkus-3-17.camel-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-azure-files</artifactId>
+                                    <version>${test.camel-quarkus-3-17.camel-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
 

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelQuarkusTestUtil.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelQuarkusTestUtil.java
@@ -30,6 +30,10 @@ public class CamelQuarkusTestUtil {
         return recipeForVersion("3.17", spec, activeRecipes);
     }
 
+    public static RecipeSpec recipe3_18(RecipeSpec spec, String... activeRecipes) {
+        return recipeForVersion("3.18", spec, activeRecipes);
+    }
+
     private static RecipeSpec recipeForVersion(String version, RecipeSpec spec, String... activeRecipes) {
         if(activeRecipes.length == 0) {
             return recipe(spec, version);
@@ -45,6 +49,7 @@ public class CamelQuarkusTestUtil {
             case "3alpha" -> new String[] {"io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe"};
             case "3.15" -> new String[] {"io.quarkus.updates.camel.camel47.CamelQuarkusMigrationRecipe"};
             case "3.17" -> new String[] {"io.quarkus.updates.camel.camel49.CamelQuarkusMigrationRecipe"};
+            case "3.18" -> new String[] {"io.quarkus.updates.camel.camel410.CamelQuarkusMigrationRecipe"};
             default -> throw new IllegalArgumentException("Version '" + version + "' is not allowed!");
         };
         return recipe(spec, version, defaultRecipes);

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate410Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate410Test.java
@@ -1,19 +1,16 @@
 package io.quarkus.updates.camel;
 
-import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.TypeValidation;
 
-import static org.openrewrite.java.Assertions.java;
-
-public class CamelUpdate49Test extends org.apache.camel.upgrade.CamelUpdate49Test {
+public class CamelUpdate410Test extends org.apache.camel.upgrade.CamelUpdate410Test {
 
     @Override
     public void defaults(RecipeSpec spec) {
         //let the parser be initialized in the camel parent
         super.defaults(spec);
         //recipe has to be loaded differently
-        CamelQuarkusTestUtil.recipe3_17(spec)
+        CamelQuarkusTestUtil.recipe3_18(spec)
                 .typeValidationOptions(TypeValidation.none());
     }
 }

--- a/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3.18.yaml
+++ b/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3.18.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2021 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide.html
+#####
+
+#####
+# Update the Camel - Quarkus extensions
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.camel.camel410.CamelQuarkusMigrationRecipe
+displayName: Migrates `camel 4.9` application to `camel 4.10`
+description: Migrates `camel 4.9` quarkus application to `camel 4.10`.
+recipeList:
+#  use the recipe from camel upgrade recipes project
+  - org.apache.camel.upgrade.camel410.CamelMigrationRecipe


### PR DESCRIPTION
fixes https://github.com/quarkusio/quarkus-updates/issues/266

Bump of camel-upgrade-recipes and removed workaround in the `CamelUpdate49Test.java`.