### PR TITLE
Fix type in Minio 3.8 upade recipes

### DIFF
--- a/recipes/src/main/resources/quarkus-updates/io.quarkiverse.minio/quarkus-minio/3.8.yaml
+++ b/recipes/src/main/resources/quarkus-updates/io.quarkiverse.minio/quarkus-minio/3.8.yaml
@@ -1,5 +1,5 @@
 type: specs.openrewrite.org/v1beta/recipe
-name: io.quakus.updates.minio.minio38.UpdateAll
+name: io.quarkus.updates.minio.minio38.UpdateAll
 recipeList:
   - io.quarkus.updates.minio.minio38.UpdateProperties
   - io.quarkus.updates.quarkiverse.minio.minio38.AdjustURLPropertyValue


### PR DESCRIPTION
I found the typo because it breaks OpenRewrites documentation generation.