### PR TITLE
Update spelling from `quakus` to `quarkus` on recipe name

### DIFF
--- a/recipes/src/main/resources/quarkus-updates/io.quarkiverse.minio/quarkus-minio/3.8.yaml
+++ b/recipes/src/main/resources/quarkus-updates/io.quarkiverse.minio/quarkus-minio/3.8.yaml
@@ -1,5 +1,5 @@
 type: specs.openrewrite.org/v1beta/recipe
-name: io.quakus.updates.minio.minio38.UpdateAll
+name: io.quarkus.updates.minio.minio38.UpdateAll
 recipeList:
   - io.quarkus.updates.minio.minio38.UpdateProperties
   - io.quarkus.updates.quarkiverse.minio.minio38.AdjustURLPropertyValue


### PR DESCRIPTION
Appears to be a typo