### PR TITLE
Upgrade to openrewrite-recipe-bom 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
         <!-- Make sure all these versions are aligned and use a compatible OpenRewrite version -->
         <!-- The rewrite-recipe-bom release notes should contain the Maven and Gradle plugin versions to target -->
         <!-- https://central.sonatype.com/artifact/org.openrewrite.recipe/rewrite-recipe-bom/versions -->
-        <rewrite-recipe-bom.version>3.4.0</rewrite-recipe-bom.version>
+        <rewrite-recipe-bom.version>3.9.0</rewrite-recipe-bom.version>
         <!--   https://central.sonatype.com/artifact/org.openrewrite.maven/rewrite-maven-plugin/versions -->
-        <rewrite-maven-plugin.version>6.3.0</rewrite-maven-plugin.version>
+        <rewrite-maven-plugin.version>6.10.0</rewrite-maven-plugin.version>
         <!--   https://plugins.gradle.org/plugin/org.openrewrite.rewrite -->
-        <rewrite-gradle-plugin.version>7.2.0</rewrite-gradle-plugin.version>
+        <rewrite-gradle-plugin.version>7.7.0</rewrite-gradle-plugin.version>
         <!-- https://github.com/apache/camel-upgrade-recipes -->
         <camel-upgrade-recipes.version>4.12.0</camel-upgrade-recipes.version>
         <!-- align with https://central.sonatype.com/artifact/org.openrewrite/rewrite-core -->


### PR DESCRIPTION
See https://github.com/openrewrite/rewrite-recipe-bom/releases/tag/v3.9.0

I would need this  to take advantage of typetable generation: https://docs.openrewrite.org/authoring-recipes/multiple-versions#typetable-generation-for-maven-projects