### PR TITLE
Bumped open rewrite and camel recipes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,13 @@
         <!-- Make sure all these versions are aligned and use a compatible OpenRewrite version -->
         <!-- The rewrite-recipe-bom release notes should contain the Maven and Gradle plugin versions to target -->
         <!-- https://central.sonatype.com/artifact/org.openrewrite.recipe/rewrite-recipe-bom/versions -->
-        <rewrite-recipe-bom.version>3.4.0</rewrite-recipe-bom.version>
+        <rewrite-recipe-bom.version>3.9.0</rewrite-recipe-bom.version>
         <!--   https://central.sonatype.com/artifact/org.openrewrite.maven/rewrite-maven-plugin/versions -->
-        <rewrite-maven-plugin.version>6.3.0</rewrite-maven-plugin.version>
+        <rewrite-maven-plugin.version>6.10.0</rewrite-maven-plugin.version>
         <!--   https://plugins.gradle.org/plugin/org.openrewrite.rewrite -->
-        <rewrite-gradle-plugin.version>7.2.0</rewrite-gradle-plugin.version>
+        <rewrite-gradle-plugin.version>7.7.0</rewrite-gradle-plugin.version>
         <!-- https://github.com/apache/camel-upgrade-recipes -->
-        <camel-upgrade-recipes.version>4.12.0</camel-upgrade-recipes.version>
+        <camel-upgrade-recipes.version>4.12.1</camel-upgrade-recipes.version>
         <!-- align with https://central.sonatype.com/artifact/org.openrewrite/rewrite-core -->
         <micrometer-core.version>1.9.17</micrometer-core.version>
         <!-- tests-->

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate45Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate45Test.java
@@ -20,7 +20,7 @@ public class CamelUpdate45Test extends org.apache.camel.upgrade.CamelUpdate45Tes
 
     @Test
     @Override
-    public void testSearch() {
+    public void testElasticSearch() {
         //test has to be changed, because the result of camel 4.5 migration is a;so migrated in camel 4.6,
         // therefore camel-quarkus migration from 3.8 to 3.15 has to expect both changes
         rewriteRun(java(
@@ -29,18 +29,40 @@ public class CamelUpdate45Test extends org.apache.camel.upgrade.CamelUpdate45Tes
                                  public void test() {
                              
                                      org.apache.camel.component.es.aggregation.BulkRequestAggregationStrategy elasticAggregationStrategy = null;
-                                     org.apache.camel.component.opensearch.aggregation.BulkRequestAggregationStrategy openAggregationStrategy = null;
                                  }
                             }
                         """,
                 """
                             import org.apache.camel.component.es.aggregation.ElasticsearchBulkRequestAggregationStrategy;
-                            import org.apache.camel.component.opensearch.aggregation.OpensearchBulkRequestAggregationStrategy;
                             
                             public class SearchTest {
                                  public void test() {
                             
                                      ElasticsearchBulkRequestAggregationStrategy elasticAggregationStrategy = null;
+                                 }
+                            }
+                        """));
+    }
+    @Test
+    @Override
+    public void testOpenSearch() {
+        //test has to be changed, because the result of camel 4.5 migration is a;so migrated in camel 4.6,
+        // therefore camel-quarkus migration from 3.8 to 3.15 has to expect both changes
+        rewriteRun(java(
+                """
+                            public class SearchTest {
+                                 public void test() {
+                             
+                                     org.apache.camel.component.opensearch.aggregation.BulkRequestAggregationStrategy openAggregationStrategy = null;
+                                 }
+                            }
+                        """,
+                """
+                            import org.apache.camel.component.opensearch.aggregation.OpensearchBulkRequestAggregationStrategy;
+                            
+                            public class SearchTest {
+                                 public void test() {
+                            
                                      OpensearchBulkRequestAggregationStrategy openAggregationStrategy = null;
                                  }
                             }

--- a/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate46Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/camel/CamelUpdate46Test.java
@@ -24,7 +24,17 @@ public class CamelUpdate46Test extends org.apache.camel.upgrade.CamelUpdate46Tes
 
     @Disabled
     @Override
+    public void testLangchainEmbeddings2() {
+    }
+
+    @Disabled
+    @Override
     public void testLangchainChat() {
+    }
+
+    @Disabled
+    @Override
+    public void testLangchainChat2() {
 
     }
 


### PR DESCRIPTION
Replaces https://github.com/quarkusio/quarkus-updates/pull/309

Upgrade of openrewrite to 3.9.0 and camel-upgrade-recipes to 4.12.1

The staging repo commit will be removed once the release is completed. (that's why this PR is draft, to see CI results)