### PR TITLE
Add `quarkus.keycloak.policy-enforcer` property to recipe

### DIFF
--- a/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate326Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate326Test.java
@@ -46,6 +46,7 @@ public class CoreUpdate326Test implements RewriteTest {
             quarkus.smallrye-graphql.ui.enable=true
             quarkus.smallrye-openapi.enable=true
             quarkus.swagger-ui.enable=true
+            quarkus.keycloak.policy-enforcer.enable=true
             """;
 
         @Language("properties")
@@ -71,6 +72,7 @@ public class CoreUpdate326Test implements RewriteTest {
             quarkus.smallrye-graphql.ui.enabled=true
             quarkus.smallrye-openapi.enabled=true
             quarkus.swagger-ui.enabled=true
+            quarkus.keycloak.policy-enforcer.enabled=true
             """;
 
         rewriteRun(properties(originalProperties, afterProperties, spec -> spec.path("src/main/resources/application.properties")));

--- a/recipes/src/main/resources/quarkus-updates/core/3.26.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.26.alpha1.yaml
@@ -65,3 +65,6 @@ recipeList:
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
       oldPropertyKey: quarkus\.swagger-ui\.enable
       newPropertyKey: quarkus.swagger-ui.enabled
+  - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
+      oldPropertyKey: quarkus\.keycloak\.policy-enforcer\.enable
+      newPropertyKey: quarkus.keycloak.policy-enforcer.enabled


### PR DESCRIPTION
`quarkus.keycloak.policy-enforcer`  was also changed but not added in recipe, probably because it's missing in migration guide as well https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.26#enable--enabled-in-configuration-properties-gear-white_check_mark