### PR TITLE
Fix update of `quarkus.log.handler.` async enabled flags

### DIFF
--- a/recipes/src/main/resources/quarkus-updates/core/3.26.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.26.alpha1.yaml
@@ -30,25 +30,25 @@ recipeList:
       oldPropertyKey: quarkus\.log\.handler\.console\.(.*)\.enable
       newPropertyKey: quarkus\.log\.handler\.console\.$1\.enabled
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
-      oldPropertyKey: quarkus\.log\.handler\.console\.(.*)\.enable
+      oldPropertyKey: quarkus\.log\.handler\.console\.(.*)\.async\.enable
       newPropertyKey: quarkus\.log\.handler\.console\.$1\.async\.enabled
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
       oldPropertyKey: quarkus\.log\.handler\.file\.(.*)\.enable
       newPropertyKey: quarkus\.log\.handler\.file\.$1\.enabled
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
-      oldPropertyKey: quarkus\.log\.handler\.file\.(.*)\.enable
+      oldPropertyKey: quarkus\.log\.handler\.file\.(.*)\.async\.enable
       newPropertyKey: quarkus\.log\.handler\.file\.$1\.async\.enabled
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
       oldPropertyKey: quarkus\.log\.handler\.syslog\.(.*)\.enable
       newPropertyKey: quarkus\.log\.handler\.syslog\.$1\.enabled
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
-      oldPropertyKey: quarkus\.log\.handler\.syslog\.(.*)\.enable
+      oldPropertyKey: quarkus\.log\.handler\.syslog\.(.*)\.async\.enable
       newPropertyKey: quarkus\.log\.handler\.syslog\.$1\.async\.enabled
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
       oldPropertyKey: quarkus\.log\.handler\.socket\.(.*)\.enable
       newPropertyKey: quarkus\.log\.handler\.socket\.$1\.enabled
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
-      oldPropertyKey: quarkus\.log\.handler\.socket\.(.*)\.enable
+      oldPropertyKey: quarkus\.log\.handler\.socket\.(.*)\.async\.enable
       newPropertyKey: quarkus\.log\.handler\.socket\.$1\.async\.enabled
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
       oldPropertyKey: quarkus\.snapstart\.enable


### PR DESCRIPTION
Currently recipes expect to rewrite the same `oldPropertyKey` into 2 different `newPropertyKey`, which doesn't make sense and I think must had been a typo. Also it doesn't work.