### PR TITLE
Add Hibernate ORM 7 migration recipes for 5 breaking changes

### DIFF
--- a/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate324Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate324Test.java
@@ -985,6 +985,143 @@ public class CoreUpdate324Test implements RewriteTest {
     }
 
     @Test
+    void testQueryHints() {
+        //language=java
+        rewriteRun(java("""
+                package com.acme;
+
+                import org.hibernate.annotations.QueryHints;
+
+                public class MyRepository {
+                    public void doThings() {
+                        String readOnly = QueryHints.READ_ONLY;
+                        String comment = QueryHints.COMMENT;
+                    }
+                }
+                """, """
+                package com.acme;
+
+                import org.hibernate.jpa.AvailableHints;
+
+                public class MyRepository {
+                    public void doThings() {
+                        String readOnly = AvailableHints.HINT_READ_ONLY;
+                        String comment = AvailableHints.HINT_COMMENT;
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testEmptyInterceptor() {
+        //language=java
+        rewriteRun(java("""
+                package com.acme;
+
+                import org.hibernate.EmptyInterceptor;
+
+                public class MyInterceptor extends EmptyInterceptor {
+                    @Override
+                    public String onPrepareStatement(String sql) {
+                        return sql;
+                    }
+                }
+                """, """
+                package com.acme;
+
+                import org.hibernate.Interceptor;
+
+                import java.io.Serializable;
+
+                public class MyInterceptor implements Interceptor, Serializable {
+                    @Override
+                    public String onPrepareStatement(String sql) {
+                        return sql;
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testHibernateValidatorNotBlank() {
+        //language=java
+        rewriteRun(java("""
+                package com.acme;
+
+                import org.hibernate.validator.constraints.NotBlank;
+
+                public class MyEntity {
+                    @NotBlank
+                    public String name;
+                }
+                """, """
+                package com.acme;
+
+                import jakarta.validation.constraints.NotBlank;
+
+                public class MyEntity {
+                    @NotBlank
+                    public String name;
+                }
+                """));
+    }
+
+    @Test
+    void testIndexColumn() {
+        //language=java
+        rewriteRun(java("""
+                package com.acme;
+
+                import org.hibernate.annotations.IndexColumn;
+                import java.util.List;
+
+                public class MyEntity {
+                    @IndexColumn(name = "position")
+                    public List<String> items;
+                }
+                """, """
+                package com.acme;
+
+                import jakarta.persistence.OrderColumn;
+
+                import java.util.List;
+
+                public class MyEntity {
+                    @OrderColumn(name = "position")
+                    public List<String> items;
+                }
+                """));
+    }
+
+    @Test
+    void testDefaultUniqueDelegate() {
+        //language=java
+        rewriteRun(java("""
+                package com.acme;
+
+                import org.hibernate.dialect.Dialect;
+                import org.hibernate.dialect.unique.DefaultUniqueDelegate;
+
+                public class MyDialect extends Dialect {
+                    public Object getUniqueDelegate() {
+                        return new DefaultUniqueDelegate(this);
+                    }
+                }
+                """, """
+                package com.acme;
+
+                import org.hibernate.dialect.Dialect;
+                import org.hibernate.dialect.unique.AlterTableUniqueDelegate;
+
+                public class MyDialect extends Dialect {
+                    public Object getUniqueDelegate() {
+                        return new AlterTableUniqueDelegate(this);
+                    }
+                }
+                """));
+    }
+
+    @Test
     void testQuarkusLogConsoleAsyncRewrite() {
         @Language("properties")
         String originalProperties = """

--- a/recipes-tests/src/test/java/io/quarkus/updates/core/hibernate/HibernateOrm66.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/core/hibernate/HibernateOrm66.java
@@ -178,6 +178,71 @@ public class HibernateOrm66 {
 				DELETE_ORPHAN
 			}
 			"""
+		, """
+			package org.hibernate.annotations;
+			public class QueryHints {
+				public static final String READ_ONLY = "org.hibernate.readOnly";
+				public static final String COMMENT = "org.hibernate.comment";
+			}
+			""", """
+			package org.hibernate.jpa;
+			public class AvailableHints {
+				public static final String HINT_READ_ONLY = "org.hibernate.readOnly";
+				public static final String HINT_COMMENT = "org.hibernate.comment";
+			}
+			""", """
+			package org.hibernate;
+			public interface Interceptor {
+			}
+			""", """
+			package org.hibernate;
+			public abstract class EmptyInterceptor implements Interceptor, java.io.Serializable {
+			}
+			""", """
+			package org.hibernate.validator.constraints;
+			@java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.FIELD})
+			@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+			public @interface NotBlank {
+			}
+			""", """
+			package jakarta.validation.constraints;
+			@java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.FIELD})
+			@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+			public @interface NotBlank {
+			}
+			""", """
+			package org.hibernate.annotations;
+			@java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.FIELD})
+			@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+			public @interface IndexColumn {
+				String name() default "";
+			}
+			""", """
+			package jakarta.persistence;
+			@java.lang.annotation.Target({java.lang.annotation.ElementType.METHOD, java.lang.annotation.ElementType.FIELD})
+			@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+			public @interface OrderColumn {
+				String name() default "";
+			}
+			""", """
+			package org.hibernate.dialect;
+			public abstract class Dialect {
+			}
+			""", """
+			package org.hibernate.dialect.unique;
+			import org.hibernate.dialect.Dialect;
+			public class DefaultUniqueDelegate {
+				public DefaultUniqueDelegate(Dialect dialect) {
+				}
+			}
+			""", """
+			package org.hibernate.dialect.unique;
+			import org.hibernate.dialect.Dialect;
+			public class AlterTableUniqueDelegate {
+				public AlterTableUniqueDelegate(Dialect dialect) {
+				}
+			}
+			"""
 		};
 		return apis;
 	}

--- a/recipes-tests/src/test/java/io/quarkus/updates/core/hibernate/HibernateOrm66.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/core/hibernate/HibernateOrm66.java
@@ -182,13 +182,35 @@ public class HibernateOrm66 {
 			package org.hibernate.annotations;
 			public class QueryHints {
 				public static final String READ_ONLY = "org.hibernate.readOnly";
+				public static final String CACHEABLE = "org.hibernate.cacheable";
+				public static final String CACHE_MODE = "org.hibernate.cacheMode";
+				public static final String CACHE_REGION = "org.hibernate.cacheRegion";
 				public static final String COMMENT = "org.hibernate.comment";
+				public static final String FETCH_SIZE = "org.hibernate.fetchSize";
+				public static final String FLUSH_MODE = "org.hibernate.flushMode";
+				public static final String TIMEOUT_HIBERNATE = "org.hibernate.timeout";
+				public static final String TIMEOUT_JAKARTA_JPA = "jakarta.persistence.query.timeout";
+				public static final String NATIVE_LOCKMODE = "org.hibernate.lockMode";
+				public static final String FOLLOW_ON_LOCKING = "org.hibernate.followOnLocking";
+				public static final String NATIVE_SPACES = "org.hibernate.query.native.spaces";
+				public static final String CALLABLE_FUNCTION = "org.hibernate.callableFunction";
+				public static final String TIMEOUT_JPA = "javax.persistence.query.timeout";
 			}
 			""", """
 			package org.hibernate.jpa;
 			public class AvailableHints {
 				public static final String HINT_READ_ONLY = "org.hibernate.readOnly";
+				public static final String HINT_CACHEABLE = "org.hibernate.cacheable";
+				public static final String HINT_CACHE_MODE = "org.hibernate.cacheMode";
+				public static final String HINT_CACHE_REGION = "org.hibernate.cacheRegion";
 				public static final String HINT_COMMENT = "org.hibernate.comment";
+				public static final String HINT_FETCH_SIZE = "org.hibernate.fetchSize";
+				public static final String HINT_FLUSH_MODE = "org.hibernate.flushMode";
+				public static final String HINT_TIMEOUT = "org.hibernate.timeout";
+				public static final String HINT_NATIVE_LOCK_MODE = "org.hibernate.lockMode";
+				public static final String HINT_FOLLOW_ON_LOCKING = "org.hibernate.followOnLocking";
+				public static final String HINT_NATIVE_SPACES = "org.hibernate.query.native.spaces";
+				public static final String HINT_CALLABLE_FUNCTION = "org.hibernate.callableFunction";
 			}
 			""", """
 			package org.hibernate;

--- a/recipes/src/main/java/io/quarkus/updates/core/quarkus324/MigrateFromEmptyInterceptor.java
+++ b/recipes/src/main/java/io/quarkus/updates/core/quarkus324/MigrateFromEmptyInterceptor.java
@@ -1,0 +1,102 @@
+package io.quarkus.updates.core.quarkus324;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.marker.Markers;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class MigrateFromEmptyInterceptor extends Recipe {
+
+    private static final String EMPTY_INTERCEPTOR = "org.hibernate.EmptyInterceptor";
+    private static final String INTERCEPTOR = "org.hibernate.Interceptor";
+    private static final String SERIALIZABLE = "java.io.Serializable";
+
+    @Override
+    public String getDisplayName() {
+        return "Replace `EmptyInterceptor` with `Interceptor`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace `extends EmptyInterceptor` with `implements Interceptor, Serializable` as `EmptyInterceptor` was removed in Hibernate ORM 7.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+
+                TypeTree extendsClause = cd.getExtends();
+                if (extendsClause == null) {
+                    return cd;
+                }
+
+                JavaType extendsType = extendsClause.getType();
+                if (extendsType == null || !(extendsType instanceof JavaType.FullyQualified)) {
+                    return cd;
+                }
+
+                if (!EMPTY_INTERCEPTOR.equals(((JavaType.FullyQualified) extendsType).getFullyQualifiedName())) {
+                    return cd;
+                }
+
+                cd = cd.withExtends(null);
+
+                JavaType.FullyQualified interceptorType = JavaType.ShallowClass.build(INTERCEPTOR);
+                JavaType.FullyQualified serializableType = JavaType.ShallowClass.build(SERIALIZABLE);
+
+                J.Identifier interceptorId = new J.Identifier(
+                        java.util.UUID.randomUUID(),
+                        Space.format(" "),
+                        Markers.EMPTY,
+                        List.of(),
+                        "Interceptor",
+                        interceptorType,
+                        null);
+
+                J.Identifier serializableId = new J.Identifier(
+                        java.util.UUID.randomUUID(),
+                        Space.format(" "),
+                        Markers.EMPTY,
+                        List.of(),
+                        "Serializable",
+                        serializableType,
+                        null);
+
+                List<JRightPadded<TypeTree>> implementsList = new ArrayList<>();
+                implementsList.add(JRightPadded.build((TypeTree) interceptorId).withAfter(Space.EMPTY));
+                implementsList.add(JRightPadded.build((TypeTree) serializableId).withAfter(Space.EMPTY));
+
+                JContainer<TypeTree> implementsContainer = JContainer.build(
+                        Space.format(" "),
+                        implementsList,
+                        Markers.EMPTY);
+
+                cd = cd.getPadding().withImplements(implementsContainer);
+
+                maybeRemoveImport(EMPTY_INTERCEPTOR);
+                maybeAddImport(INTERCEPTOR);
+                maybeAddImport(SERIALIZABLE);
+
+                return cd;
+            }
+        };
+    }
+}

--- a/recipes/src/main/resources/quarkus-updates/core/3.24.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.24.alpha1.yaml
@@ -144,3 +144,59 @@ recipeList:
   - org.openrewrite.quarkus.ChangeQuarkusPropertyKey:
       oldPropertyKey: quarkus\.log\.console\.async
       newPropertyKey: quarkus.log.console.async.enable
+
+#####
+# Replace removed QueryHints constants with AvailableHints equivalents.
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus324.MigrateFromHibernateOrmQueryHints
+recipeList:
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.READ_ONLY
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_READ_ONLY
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.COMMENT
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_COMMENT
+
+#####
+# Replace removed EmptyInterceptor with Interceptor interface.
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus324.MigrateFromHibernateOrmEmptyInterceptor
+recipeList:
+  - io.quarkus.updates.core.quarkus324.MigrateFromEmptyInterceptor
+
+#####
+# Replace deprecated Hibernate Validator NotBlank with Jakarta Validation equivalent.
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus324.MigrateFromHibernateValidatorNotBlank
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.hibernate.validator.constraints.NotBlank
+      newFullyQualifiedTypeName: jakarta.validation.constraints.NotBlank
+
+#####
+# Replace removed IndexColumn with standard JPA OrderColumn.
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus324.MigrateFromIndexColumn
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.hibernate.annotations.IndexColumn
+      newFullyQualifiedTypeName: jakarta.persistence.OrderColumn
+
+#####
+# Replace removed DefaultUniqueDelegate with AlterTableUniqueDelegate.
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus324.MigrateFromDefaultUniqueDelegate
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.hibernate.dialect.unique.DefaultUniqueDelegate
+      newFullyQualifiedTypeName: org.hibernate.dialect.unique.AlterTableUniqueDelegate

--- a/recipes/src/main/resources/quarkus-updates/core/3.24.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.24.alpha1.yaml
@@ -156,8 +156,44 @@ recipeList:
       existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.READ_ONLY
       fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_READ_ONLY
   - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.CACHEABLE
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_CACHEABLE
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.CACHE_MODE
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_CACHE_MODE
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.CACHE_REGION
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_CACHE_REGION
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
       existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.COMMENT
       fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_COMMENT
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.FETCH_SIZE
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_FETCH_SIZE
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.FLUSH_MODE
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_FLUSH_MODE
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.TIMEOUT_HIBERNATE
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_TIMEOUT
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.TIMEOUT_JAKARTA_JPA
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_TIMEOUT
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.NATIVE_LOCKMODE
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_NATIVE_LOCK_MODE
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.FOLLOW_ON_LOCKING
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_FOLLOW_ON_LOCKING
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.NATIVE_SPACES
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_NATIVE_SPACES
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.CALLABLE_FUNCTION
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_CALLABLE_FUNCTION
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.hibernate.annotations.QueryHints.TIMEOUT_JPA
+      fullyQualifiedConstantName: org.hibernate.jpa.AvailableHints.HINT_TIMEOUT
 
 #####
 # Replace removed EmptyInterceptor with Interceptor interface.


### PR DESCRIPTION
Adds OpenRewrite recipes to automate migrations for:
- QueryHints.READ_ONLY/COMMENT → AvailableHints equivalents
- EmptyInterceptor extends → Interceptor/Serializable implements
- Hibernate Validator NotBlank → Jakarta Validation NotBlank
- IndexColumn → JPA OrderColumn
- DefaultUniqueDelegate → AlterTableUniqueDelegate

Fixes #463
