### PR TITLE
Use Google Maven Central mirror to avoid rate limiting

### DIFF
--- a/.github/mvn-settings.xml
+++ b/.github/mvn-settings.xml
@@ -1,0 +1,11 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>google-maven-central</id>
+      <name>GCS Maven Central mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ defaults:
 env:
   MAVEN_OPTS: -Xmx8g
   GRADLE_OPTS: -Dorg.gradle.jvmargs='-Xmx8g'
+  MVNW_REPOURL: https://maven-central.storage-download.googleapis.com/maven2
 
 jobs:
   build:
@@ -59,7 +60,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn --batch-mode --no-transfer-progress clean install -Dno-format -Dstyle.color=always
+        run: mvn -s .github/mvn-settings.xml --batch-mode --no-transfer-progress clean install -Dno-format -Dstyle.color=always
 
       # Publish build reports
       - name: Prepare build reports archive


### PR DESCRIPTION
## Summary

Configure Maven to use Google's Maven Central mirror to avoid HTTP 429 rate limiting errors.

## Changes

- Add `.github/mvn-settings.xml` with `<mirror>` configuration
- Update build workflow to use settings file: `-s .github/mvn-settings.xml`
- Add `MVNW_REPOURL` env variable for Maven wrapper

## Key Difference from PR #469

Uses `<mirrors>` instead of `<repositories>`. Mirrors redirect all Maven Central requests (including from OpenRewrite), while repositories only add additional sources. This fixes the OpenRewrite test failures seen in #469.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>