### PR TITLE
Add OpenRewrite recipe for Panache Next to Quarkus Data relocation

### DIFF
--- a/recipes/src/main/resources/quarkus-updates/core/3.37.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.37.alpha1.yaml
@@ -1,0 +1,15 @@
+#####
+# Relocations for Panache Next to Quarkus Data Hibernate rename
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus337.PanacheNextRelocations
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-hibernate-panache-next
+      newArtifactId: quarkus-data-hibernate
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: io.quarkus
+      oldArtifactId: quarkus-hibernate-panache-next-deployment
+      newArtifactId: quarkus-data-hibernate-deployment


### PR DESCRIPTION
## Summary

- Add `ChangeDependency` recipes to `3.37.alpha1.yaml` for:
  - `quarkus-hibernate-panache-next` -> `quarkus-data-hibernate`
  - `quarkus-hibernate-panache-next-deployment` -> `quarkus-data-hibernate-deployment`

Companion PR on quarkus: https://github.com/quarkusio/quarkus/pull/54535