### PR TITLE
Quarkus data rename types

### DIFF
--- a/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate338Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate338Test.java
@@ -91,11 +91,298 @@ public class CoreUpdate338Test implements RewriteTest {
                     void cancel();
                 }
                 """;
+        @Language("java")
+        String panacheClass = """
+                package io.quarkus.hibernate.panache;
+
+                public class Panache {
+                }
+                """;
+        @Language("java")
+        String panacheQueryInterface = """
+                package io.quarkus.hibernate.panache;
+
+                public interface PanacheQuery<Entity> {
+                }
+                """;
+        @Language("java")
+        String withId = """
+                package io.quarkus.hibernate.panache;
+
+                public interface WithId<Id> {
+                    public abstract class AutoLong implements WithId<Long> {
+                    }
+                }
+                """;
+        @Language("java")
+        String panacheManagedBlockingEntity = """
+                package io.quarkus.hibernate.panache.managed.blocking;
+
+                public interface PanacheManagedBlockingEntity {
+                }
+                """;
+        @Language("java")
+        String panacheStatelessBlockingEntity = """
+                package io.quarkus.hibernate.panache.stateless.blocking;
+
+                public interface PanacheStatelessBlockingEntity {
+                }
+                """;
+        @Language("java")
+        String panacheManagedReactiveEntity = """
+                package io.quarkus.hibernate.panache.managed.reactive;
+
+                public interface PanacheManagedReactiveEntity {
+                }
+                """;
+        @Language("java")
+        String panacheStatelessReactiveEntity = """
+                package io.quarkus.hibernate.panache.stateless.reactive;
+
+                public interface PanacheStatelessReactiveEntity {
+                }
+                """;
+        @Language("java")
+        String panacheEntity = """
+                package io.quarkus.hibernate.panache;
+
+                import io.quarkus.hibernate.panache.managed.blocking.PanacheManagedBlockingEntity;
+                import io.quarkus.hibernate.panache.managed.reactive.PanacheManagedReactiveEntity;
+                import io.quarkus.hibernate.panache.stateless.blocking.PanacheStatelessBlockingEntity;
+                import io.quarkus.hibernate.panache.stateless.reactive.PanacheStatelessReactiveEntity;
+
+                public abstract class PanacheEntity extends WithId.AutoLong implements PanacheManagedBlockingEntity {
+                    public interface Managed extends PanacheManagedBlockingEntity {}
+                    public interface Stateless extends PanacheStatelessBlockingEntity {}
+                    public interface Reactive extends PanacheManagedReactiveEntity {
+                        public interface Stateless extends PanacheStatelessReactiveEntity {}
+                    }
+                }
+                """;
+        @Language("java")
+        String panacheEntityBase = """
+                package io.quarkus.hibernate.panache;
+
+                import io.quarkus.hibernate.panache.managed.blocking.PanacheManagedBlockingEntity;
+
+                public class PanacheEntityBase implements PanacheManagedBlockingEntity {
+                }
+                """;
+        @Language("java")
+        String panacheManagedBlockingRepositoryBase = """
+                package io.quarkus.hibernate.panache.managed.blocking;
+
+                public interface PanacheManagedBlockingRepositoryBase<Entity, Id> {
+                }
+                """;
+        @Language("java")
+        String panacheStatelessBlockingRepositoryBase = """
+                package io.quarkus.hibernate.panache.stateless.blocking;
+
+                public interface PanacheStatelessBlockingRepositoryBase<Entity, Id> {
+                }
+                """;
+        @Language("java")
+        String panacheManagedReactiveRepositoryBase = """
+                package io.quarkus.hibernate.panache.managed.reactive;
+
+                public interface PanacheManagedReactiveRepositoryBase<Entity, Id> {
+                }
+                """;
+        @Language("java")
+        String panacheStatelessReactiveRepositoryBase = """
+                package io.quarkus.hibernate.panache.stateless.reactive;
+
+                public interface PanacheStatelessReactiveRepositoryBase<Entity, Id> {
+                }
+                """;
+        @Language("java")
+        String panacheRepository = """
+                package io.quarkus.hibernate.panache;
+
+                import io.quarkus.hibernate.panache.managed.blocking.PanacheManagedBlockingRepositoryBase;
+                import io.quarkus.hibernate.panache.managed.reactive.PanacheManagedReactiveRepositoryBase;
+                import io.quarkus.hibernate.panache.stateless.blocking.PanacheStatelessBlockingRepositoryBase;
+                import io.quarkus.hibernate.panache.stateless.reactive.PanacheStatelessReactiveRepositoryBase;
+
+                public interface PanacheRepository<Entity> extends PanacheManagedBlockingRepositoryBase<Entity, Long> {
+                    public interface Managed<Entity, Id> extends PanacheManagedBlockingRepositoryBase<Entity, Id> {}
+                    public interface Stateless<Entity, Id> extends PanacheStatelessBlockingRepositoryBase<Entity, Id> {}
+                    public interface Reactive<Entity, Id> extends PanacheManagedReactiveRepositoryBase<Entity, Id> {
+                        public interface Stateless<Entity, Id> extends PanacheStatelessReactiveRepositoryBase<Entity, Id> {}
+                    }
+                }
+                """;
+        @Language("java")
+        String panacheEntityMarker = """
+                package io.quarkus.hibernate.panache;
+
+                public interface PanacheEntityMarker {
+                }
+                """;
+        @Language("java")
+        String panacheRepositoryQueries = """
+                package io.quarkus.hibernate.panache;
+
+                public interface PanacheRepositoryQueries {
+                }
+                """;
+        @Language("java")
+        String panacheRepositorySwitcher = """
+                package io.quarkus.hibernate.panache;
+
+                public interface PanacheRepositorySwitcher {
+                }
+                """;
+        @Language("java")
+        String panacheBlockingQuery = """
+                package io.quarkus.hibernate.panache.blocking;
+
+                public interface PanacheBlockingQuery<Entity> {
+                }
+                """;
+        @Language("java")
+        String newWithId = """
+                package io.quarkus.data.hibernate;
+
+                public interface WithId<Id> {
+                    public abstract class AutoLong implements WithId<Long> {
+                    }
+                }
+                """;
+        @Language("java")
+        String newManagedBlockingEntity = """
+                package io.quarkus.data.hibernate.managed.blocking;
+
+                public interface PanacheManagedBlockingEntity {
+                }
+                """;
+        @Language("java")
+        String newStatelessBlockingEntity = """
+                package io.quarkus.data.hibernate.stateless.blocking;
+
+                public interface PanacheStatelessBlockingEntity {
+                }
+                """;
+        @Language("java")
+        String newManagedReactiveEntity = """
+                package io.quarkus.data.hibernate.managed.reactive;
+
+                public interface PanacheManagedReactiveEntity {
+                }
+                """;
+        @Language("java")
+        String newStatelessReactiveEntity = """
+                package io.quarkus.data.hibernate.stateless.reactive;
+
+                public interface PanacheStatelessReactiveEntity {
+                }
+                """;
+        @Language("java")
+        String managedEntity = """
+                package io.quarkus.data.hibernate;
+
+                import io.quarkus.data.hibernate.managed.blocking.PanacheManagedBlockingEntity;
+                import io.quarkus.data.hibernate.managed.reactive.PanacheManagedReactiveEntity;
+
+                public class ManagedEntity extends WithId.AutoLong implements PanacheManagedBlockingEntity {
+                    public interface CustomId extends PanacheManagedBlockingEntity {}
+                    public static class Reactive extends WithId.AutoLong implements PanacheManagedReactiveEntity {
+                        public interface CustomId extends PanacheManagedReactiveEntity {}
+                    }
+                }
+                """;
+        @Language("java")
+        String recordEntity = """
+                package io.quarkus.data.hibernate;
+
+                import io.quarkus.data.hibernate.stateless.blocking.PanacheStatelessBlockingEntity;
+                import io.quarkus.data.hibernate.stateless.reactive.PanacheStatelessReactiveEntity;
+
+                public class RecordEntity extends WithId.AutoLong implements PanacheStatelessBlockingEntity {
+                    public interface CustomId extends PanacheStatelessBlockingEntity {}
+                    public static class Reactive extends WithId.AutoLong implements PanacheStatelessReactiveEntity {
+                        public interface CustomId extends PanacheStatelessReactiveEntity {}
+                    }
+                }
+                """;
+        @Language("java")
+        String newManagedBlockingRepositoryBase = """
+                package io.quarkus.data.hibernate.managed.blocking;
+
+                public interface PanacheManagedBlockingRepositoryBase<Entity, Id> {
+                }
+                """;
+        @Language("java")
+        String newStatelessBlockingRepositoryBase = """
+                package io.quarkus.data.hibernate.stateless.blocking;
+
+                public interface PanacheStatelessBlockingRepositoryBase<Entity, Id> {
+                }
+                """;
+        @Language("java")
+        String newManagedReactiveRepositoryBase = """
+                package io.quarkus.data.hibernate.managed.reactive;
+
+                public interface PanacheManagedReactiveRepositoryBase<Entity, Id> {
+                }
+                """;
+        @Language("java")
+        String newStatelessReactiveRepositoryBase = """
+                package io.quarkus.data.hibernate.stateless.reactive;
+
+                public interface PanacheStatelessReactiveRepositoryBase<Entity, Id> {
+                }
+                """;
+        @Language("java")
+        String managedRepository = """
+                package io.quarkus.data.hibernate;
+
+                import io.quarkus.data.hibernate.managed.blocking.PanacheManagedBlockingRepositoryBase;
+                import io.quarkus.data.hibernate.managed.reactive.PanacheManagedReactiveRepositoryBase;
+
+                public interface ManagedRepository<Entity> extends PanacheManagedBlockingRepositoryBase<Entity, Long> {
+                    interface CustomId<Entity, Id> extends PanacheManagedBlockingRepositoryBase<Entity, Id> {}
+                    interface Reactive<Entity> extends PanacheManagedReactiveRepositoryBase<Entity, Long> {
+                        interface CustomId<Entity, Id> extends PanacheManagedReactiveRepositoryBase<Entity, Id> {}
+                    }
+                }
+                """;
+        @Language("java")
+        String recordRepository = """
+                package io.quarkus.data.hibernate;
+
+                import io.quarkus.data.hibernate.stateless.blocking.PanacheStatelessBlockingRepositoryBase;
+                import io.quarkus.data.hibernate.stateless.reactive.PanacheStatelessReactiveRepositoryBase;
+
+                public interface RecordRepository<Entity> extends PanacheStatelessBlockingRepositoryBase<Entity, Long> {
+                    interface CustomId<Entity, Id> extends PanacheStatelessBlockingRepositoryBase<Entity, Id> {}
+                    interface Reactive<Entity> extends PanacheStatelessReactiveRepositoryBase<Entity, Long> {
+                        interface CustomId<Entity, Id> extends PanacheStatelessReactiveRepositoryBase<Entity, Id> {}
+                    }
+                }
+                """;
         CoreTestUtil.recipe(spec, Path.of("quarkus-updates", "core", "3.38.alpha1.yaml"))
                 .parser(JavaParser.fromJavaVersion()
                         .dependsOn(restClient, restClientBuilder, request, response,
                                 responseException, responseListener, requestOptions,
-                                cancellable)
+                                cancellable,
+                                panacheClass, panacheQueryInterface, withId,
+                                panacheManagedBlockingEntity, panacheStatelessBlockingEntity,
+                                panacheManagedReactiveEntity, panacheStatelessReactiveEntity,
+                                panacheEntity, panacheEntityBase,
+                                panacheManagedBlockingRepositoryBase, panacheStatelessBlockingRepositoryBase,
+                                panacheManagedReactiveRepositoryBase, panacheStatelessReactiveRepositoryBase,
+                                panacheRepository,
+                                panacheEntityMarker, panacheRepositoryQueries, panacheRepositorySwitcher,
+                                panacheBlockingQuery,
+                                newWithId,
+                                newManagedBlockingEntity, newStatelessBlockingEntity,
+                                newManagedReactiveEntity, newStatelessReactiveEntity,
+                                managedEntity, recordEntity,
+                                newManagedBlockingRepositoryBase, newStatelessBlockingRepositoryBase,
+                                newManagedReactiveRepositoryBase, newStatelessReactiveRepositoryBase,
+                                managedRepository, recordRepository)
                         .logCompilationWarningsAndErrors(true))
                 .typeValidationOptions(TypeValidation.none());
     }
@@ -213,6 +500,360 @@ public class CoreUpdate338Test implements RewriteTest {
 
                 public class MyConfigurator implements ElasticsearchClientConfigConfigurer {
                 }
+                """));
+    }
+
+    @Test
+    void testPanacheToQuarkusDataTypeRename() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.Panache;
+
+                    class MyService {
+                        void doSomething() {
+                            Panache.withTransaction(() -> null);
+                        }
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.QuarkusData;
+
+                    class MyService {
+                        void doSomething() {
+                            QuarkusData.withTransaction(() -> null);
+                        }
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheQueryToDataQuery() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheQuery;
+
+                    class MyService {
+                        PanacheQuery<Object> query;
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.DataQuery;
+
+                    class MyService {
+                        DataQuery<Object> query;
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheEntityToManagedEntity() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheEntity;
+
+                    public class MyEntity extends PanacheEntity {
+                        public String name;
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.ManagedEntity;
+
+                    public class MyEntity extends ManagedEntity {
+                        public String name;
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheEntityBaseToManagedEntityCustomId() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheEntityBase;
+
+                    public class MyEntity extends PanacheEntityBase {
+                        public String name;
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.ManagedEntity;
+
+                    public class MyEntity extends ManagedEntity.CustomId {
+                        public String name;
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheEntityManagedInnerType() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheEntity;
+
+                    public class MyEntity implements PanacheEntity.Managed {
+                        public String name;
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.ManagedEntity;
+
+                    public class MyEntity implements ManagedEntity.CustomId {
+                        public String name;
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheEntityStatelessInnerType() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheEntity;
+
+                    public class MyEntity implements PanacheEntity.Stateless {
+                        public String name;
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.RecordEntity;
+
+                    public class MyEntity implements RecordEntity.CustomId {
+                        public String name;
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheEntityReactiveInnerType() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheEntity;
+
+                    public class MyEntity implements PanacheEntity.Reactive {
+                        public String name;
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.ManagedEntity;
+
+                    public class MyEntity implements ManagedEntity.Reactive.CustomId {
+                        public String name;
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheEntityReactiveStatelessInnerType() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheEntity;
+
+                    public class MyEntity implements PanacheEntity.Reactive.Stateless {
+                        public String name;
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.RecordEntity;
+
+                    public class MyEntity implements RecordEntity.Reactive.CustomId {
+                        public String name;
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheRepositoryToManagedRepository() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheRepository;
+
+                    public class MyRepository implements PanacheRepository<Object> {
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.ManagedRepository;
+
+                    public class MyRepository implements ManagedRepository<Object> {
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheRepositoryStatelessToRecordRepository() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheRepository;
+
+                    public class MyRepository implements PanacheRepository.Stateless<Object, Long> {
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.RecordRepository;
+
+                    public class MyRepository implements RecordRepository.CustomId<Object, Long> {
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheRepositoryReactiveToManagedRepositoryReactive() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheRepository;
+
+                    public class MyRepository implements PanacheRepository.Reactive<Object, Long> {
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.ManagedRepository;
+
+                    public class MyRepository implements ManagedRepository.Reactive.CustomId<Object, Long> {
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheRepositoryReactiveStatelessToRecordRepositoryReactive() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheRepository;
+
+                    public class MyRepository implements PanacheRepository.Reactive.Stateless<Object, Long> {
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.RecordRepository;
+
+                    public class MyRepository implements RecordRepository.Reactive.CustomId<Object, Long> {
+                    }
+                """));
+    }
+
+    @Test
+    void testPackageRenameForRemainingTypes() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.blocking.PanacheBlockingQuery;
+
+                    class MyService {
+                        PanacheBlockingQuery<Object> query;
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.blocking.PanacheBlockingQuery;
+
+                    class MyService {
+                        PanacheBlockingQuery<Object> query;
+                    }
+                """));
+    }
+
+    @Test
+    void testPanacheEntityMarkerToEntitySwitcher() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.PanacheEntityMarker;
+
+                    class MyService {
+                        PanacheEntityMarker marker;
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.EntitySwitcher;
+
+                    class MyService {
+                        EntitySwitcher marker;
+                    }
+                """));
+    }
+
+    @Test
+    void testWithIdPackageRename() {
+        //language=java
+        rewriteRun(java(
+                """
+                    package org.acme;
+
+                    import io.quarkus.hibernate.panache.WithId;
+
+                    class MyEntity implements WithId<Long> {
+                    }
+                """,
+                """
+                    package org.acme;
+
+                    import io.quarkus.data.hibernate.WithId;
+
+                    class MyEntity implements WithId<Long> {
+                    }
                 """));
     }
 }

--- a/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate338Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate338Test.java
@@ -1,6 +1,7 @@
 package io.quarkus.updates.core;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 import java.nio.file.Path;
@@ -915,6 +916,81 @@ public class CoreUpdate338Test implements RewriteTest {
     }
 
     @Test
+    void testHibernateProcessorWithVersionToQuarkusDataProcessor() {
+        //language=xml
+        rewriteRun(pomXml(
+                """
+                        <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>org.acme</groupId>
+                            <artifactId>my-app</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                            <dependencyManagement>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>io.quarkus</groupId>
+                                        <artifactId>quarkus-data-processor</artifactId>
+                                        <version>3.38.0</version>
+                                    </dependency>
+                                </dependencies>
+                            </dependencyManagement>
+                            <build>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <version>3.13.0</version>
+                                        <configuration>
+                                            <annotationProcessorPaths>
+                                                <path>
+                                                    <groupId>org.hibernate.orm</groupId>
+                                                    <artifactId>hibernate-processor</artifactId>
+                                                    <version>6.6.3.Final</version>
+                                                </path>
+                                            </annotationProcessorPaths>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </build>
+                        </project>
+                        """,
+                """
+                        <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>org.acme</groupId>
+                            <artifactId>my-app</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                            <dependencyManagement>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>io.quarkus</groupId>
+                                        <artifactId>quarkus-data-processor</artifactId>
+                                        <version>3.38.0</version>
+                                    </dependency>
+                                </dependencies>
+                            </dependencyManagement>
+                            <build>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <version>3.13.0</version>
+                                        <configuration>
+                                            <annotationProcessorPaths>
+                                                <path>
+                                                    <groupId>io.quarkus</groupId>
+                                                    <artifactId>quarkus-data-processor</artifactId>
+                                                </path>
+                                            </annotationProcessorPaths>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </build>
+                        </project>
+                        """));
+    }
+
+    @Test
     void testOldJpaModelgenToQuarkusDataProcessor() {
         //language=xml
         rewriteRun(pomXml(
@@ -968,5 +1044,133 @@ public class CoreUpdate338Test implements RewriteTest {
                             </build>
                         </project>
                         """));
+    }
+
+    @Test
+    void testGradleHibernateProcessorWithVersionToQuarkusDataProcessor() {
+        org.openrewrite.maven.tree.Dependency dep = org.openrewrite.maven.tree.Dependency.builder()
+                .gav(new org.openrewrite.maven.tree.GroupArtifactVersion("org.hibernate.orm", "hibernate-processor", "6.6.3.Final"))
+                .build();
+        org.openrewrite.gradle.marker.GradleDependencyConfiguration apConfig =
+                new org.openrewrite.gradle.marker.GradleDependencyConfiguration("annotationProcessor", null, true, true, true, true,
+                        java.util.Collections.emptyList(), java.util.List.of(dep), java.util.Collections.emptyList(), null, null, null, null);
+        org.openrewrite.gradle.marker.GradleProject gp = org.openrewrite.gradle.marker.GradleProject.builder()
+                .group("org.acme")
+                .name("my-app")
+                .version("1.0-SNAPSHOT")
+                .nameToConfiguration(java.util.Map.of("annotationProcessor", apConfig))
+                .build();
+        rewriteRun(
+                buildGradle(
+                        """
+                            plugins {
+                                id 'java'
+                            }
+                            repositories {
+                                mavenCentral()
+                            }
+                            dependencies {
+                                annotationProcessor enforcedPlatform("io.quarkus.platform:quarkus-bom:3.38.0")
+                                annotationProcessor 'org.hibernate.orm:hibernate-processor:6.6.3.Final'
+                            }
+                            """,
+                        """
+                            plugins {
+                                id 'java'
+                            }
+                            repositories {
+                                mavenCentral()
+                            }
+                            dependencies {
+                                annotationProcessor enforcedPlatform("io.quarkus.platform:quarkus-bom:3.38.0")
+                                annotationProcessor 'io.quarkus:quarkus-data-processor'
+                            }
+                            """,
+                        spec2 -> spec2.markers(gp)));
+    }
+
+    @Test
+    void testGradleHibernateProcessorWithoutVersionToQuarkusDataProcessor() {
+        org.openrewrite.maven.tree.Dependency dep = org.openrewrite.maven.tree.Dependency.builder()
+                .gav(new org.openrewrite.maven.tree.GroupArtifactVersion("org.hibernate.orm", "hibernate-processor", null))
+                .build();
+        org.openrewrite.gradle.marker.GradleDependencyConfiguration apConfig =
+                new org.openrewrite.gradle.marker.GradleDependencyConfiguration("annotationProcessor", null, true, true, true, true,
+                        java.util.Collections.emptyList(), java.util.List.of(dep), java.util.Collections.emptyList(), null, null, null, null);
+        org.openrewrite.gradle.marker.GradleProject gp = org.openrewrite.gradle.marker.GradleProject.builder()
+                .group("org.acme")
+                .name("my-app")
+                .version("1.0-SNAPSHOT")
+                .nameToConfiguration(java.util.Map.of("annotationProcessor", apConfig))
+                .build();
+        rewriteRun(
+                buildGradle(
+                        """
+                            plugins {
+                                id 'java'
+                            }
+                            repositories {
+                                mavenCentral()
+                            }
+                            dependencies {
+                                annotationProcessor enforcedPlatform("io.quarkus.platform:quarkus-bom:3.38.0")
+                                annotationProcessor 'org.hibernate.orm:hibernate-processor'
+                            }
+                            """,
+                        """
+                            plugins {
+                                id 'java'
+                            }
+                            repositories {
+                                mavenCentral()
+                            }
+                            dependencies {
+                                annotationProcessor enforcedPlatform("io.quarkus.platform:quarkus-bom:3.38.0")
+                                annotationProcessor 'io.quarkus:quarkus-data-processor'
+                            }
+                            """,
+                        spec2 -> spec2.markers(gp)));
+    }
+
+    @Test
+    void testGradleHibernateProcessorWithVersionNoEnforcedPlatform() {
+        org.openrewrite.maven.tree.Dependency dep = org.openrewrite.maven.tree.Dependency.builder()
+                .gav(new org.openrewrite.maven.tree.GroupArtifactVersion("org.hibernate.orm", "hibernate-processor", "6.6.3.Final"))
+                .build();
+        org.openrewrite.gradle.marker.GradleDependencyConfiguration apConfig =
+                new org.openrewrite.gradle.marker.GradleDependencyConfiguration("annotationProcessor", null, true, true, true, true,
+                        java.util.Collections.emptyList(), java.util.List.of(dep), java.util.Collections.emptyList(), null, null, null, null);
+        org.openrewrite.gradle.marker.GradleProject gp = org.openrewrite.gradle.marker.GradleProject.builder()
+                .group("org.acme")
+                .name("my-app")
+                .version("1.0-SNAPSHOT")
+                .nameToConfiguration(java.util.Map.of("annotationProcessor", apConfig))
+                .build();
+        rewriteRun(
+                buildGradle(
+                        """
+                            plugins {
+                                id 'java'
+                            }
+                            repositories {
+                                mavenCentral()
+                            }
+                            dependencies {
+                                annotationProcessor 'org.hibernate.orm:hibernate-processor:6.6.3.Final'
+                            }
+                            """,
+                        """
+                            plugins {
+                                id 'java'
+                            }
+                            repositories {
+                                mavenCentral()
+                            }
+                            dependencies {
+                                annotationProcessor enforcedPlatform("io.quarkus.platform:quarkus-bom:$quarkusPlatformVersion")
+                                annotationProcessor 'io.quarkus:quarkus-data-processor'
+                            }
+                            """,
+                        spec2 -> spec2.markers(gp)));
     }
 }

--- a/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate338Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate338Test.java
@@ -1,6 +1,7 @@
 package io.quarkus.updates.core;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
 
 import java.nio.file.Path;
 
@@ -855,5 +856,117 @@ public class CoreUpdate338Test implements RewriteTest {
                     class MyEntity implements WithId<Long> {
                     }
                 """));
+    }
+
+    @Test
+    void testHibernateProcessorToQuarkusDataProcessor() {
+        //language=xml
+        rewriteRun(pomXml(
+                """
+                        <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>org.acme</groupId>
+                            <artifactId>my-app</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                            <build>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <version>3.13.0</version>
+                                        <configuration>
+                                            <annotationProcessorPaths>
+                                                <path>
+                                                    <groupId>org.hibernate.orm</groupId>
+                                                    <artifactId>hibernate-processor</artifactId>
+                                                </path>
+                                            </annotationProcessorPaths>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </build>
+                        </project>
+                        """,
+                """
+                        <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>org.acme</groupId>
+                            <artifactId>my-app</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                            <build>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <version>3.13.0</version>
+                                        <configuration>
+                                            <annotationProcessorPaths>
+                                                <path>
+                                                    <groupId>io.quarkus</groupId>
+                                                    <artifactId>quarkus-data-processor</artifactId>
+                                                </path>
+                                            </annotationProcessorPaths>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </build>
+                        </project>
+                        """));
+    }
+
+    @Test
+    void testOldJpaModelgenToQuarkusDataProcessor() {
+        //language=xml
+        rewriteRun(pomXml(
+                """
+                        <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>org.acme</groupId>
+                            <artifactId>my-app</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                            <build>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <version>3.13.0</version>
+                                        <configuration>
+                                            <annotationProcessorPaths>
+                                                <path>
+                                                    <groupId>org.hibernate</groupId>
+                                                    <artifactId>hibernate-jpamodelgen</artifactId>
+                                                </path>
+                                            </annotationProcessorPaths>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </build>
+                        </project>
+                        """,
+                """
+                        <project>
+                            <modelVersion>4.0.0</modelVersion>
+                            <groupId>org.acme</groupId>
+                            <artifactId>my-app</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                            <build>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <version>3.13.0</version>
+                                        <configuration>
+                                            <annotationProcessorPaths>
+                                                <path>
+                                                    <groupId>io.quarkus</groupId>
+                                                    <artifactId>quarkus-data-processor</artifactId>
+                                                </path>
+                                            </annotationProcessorPaths>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </build>
+                        </project>
+                        """));
     }
 }

--- a/recipes/pom.xml
+++ b/recipes/pom.xml
@@ -177,6 +177,15 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/recipes/src/main/java/io/quarkus/updates/core/quarkus338/ChangeGradleAnnotationProcessorDependency.java
+++ b/recipes/src/main/java/io/quarkus/updates/core/quarkus338/ChangeGradleAnnotationProcessorDependency.java
@@ -1,0 +1,173 @@
+package io.quarkus.updates.core.quarkus338;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.Validated;
+import org.openrewrite.gradle.AddDependencyVisitor;
+import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
+import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.gradle.trait.GradleMultiDependency;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.semver.DependencyMatcher;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+import static java.util.Objects.requireNonNull;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ChangeGradleAnnotationProcessorDependency extends Recipe {
+
+    @Option(displayName = "Old groupId", description = "The old groupId to replace.", example = "org.hibernate.orm")
+    String oldGroupId;
+
+    @Option(displayName = "Old artifactId", description = "The old artifactId to replace.", example = "hibernate-processor")
+    String oldArtifactId;
+
+    @Option(displayName = "New groupId", description = "The new groupId to use.", example = "io.quarkus")
+    String newGroupId;
+
+    @Option(displayName = "New artifactId", description = "The new artifactId to use.", example = "quarkus-data-processor")
+    String newArtifactId;
+
+    @Override
+    public String getDisplayName() {
+        return "Change Gradle annotation processor dependency and remove version";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Change the groupId and artifactId of a Gradle annotation processor dependency, remove any explicit version, "
+                + "and add an enforcedPlatform for the Quarkus BOM if the old dependency had a version and no platform was present.";
+    }
+
+    @Override
+    public Validated<Object> validate() {
+        return super.validate().and(DependencyMatcher.build(oldGroupId + ":" + oldArtifactId));
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            final DependencyMatcher depMatcher = requireNonNull(DependencyMatcher.build(oldGroupId + ":" + oldArtifactId).getValue());
+            final MethodMatcher enforcedPlatformMatcher = new MethodMatcher("* enforcedPlatform(..)");
+
+            @SuppressWarnings("NotNullFieldNotInitialized")
+            GradleProject gradleProject;
+            boolean hasEnforcedPlatformForAP;
+            boolean oldDepHadVersion;
+
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof JavaSourceFile) {
+                    JavaSourceFile sf = (JavaSourceFile) tree;
+                    Optional<GradleProject> maybeGp = sf.getMarkers().findFirst(GradleProject.class);
+                    if (!maybeGp.isPresent()) {
+                        return sf;
+                    }
+                    gradleProject = maybeGp.get();
+                    hasEnforcedPlatformForAP = false;
+                    oldDepHadVersion = false;
+
+                    J result = super.visit(tree, ctx);
+
+                    if (result != tree && result instanceof JavaSourceFile) {
+                        JavaSourceFile updated = (JavaSourceFile) result;
+                        updated = updated.withMarkers(updated.getMarkers().setByType(updateGradleModel(gradleProject)));
+
+                        if (oldDepHadVersion && !hasEnforcedPlatformForAP) {
+                            updated = (JavaSourceFile) new AddDependencyVisitor(
+                                    "io.quarkus.platform", "quarkus-bom",
+                                    "$quarkusPlatformVersion", null,
+                                    "annotationProcessor",
+                                    null, null, null, null,
+                                    AddDependencyVisitor.DependencyModifier.ENFORCED_PLATFORM)
+                                    .visitNonNull(updated, ctx);
+                        }
+
+                        return updated;
+                    }
+                    return sf;
+                }
+                return super.visit(tree, ctx);
+            }
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+
+                if ("annotationProcessor".equals(m.getSimpleName())) {
+                    for (Expression arg : m.getArguments()) {
+                        if (arg instanceof J.MethodInvocation && enforcedPlatformMatcher.matches((J.MethodInvocation) arg, true)) {
+                            hasEnforcedPlatformForAP = true;
+                            break;
+                        }
+                    }
+                }
+
+                return GradleMultiDependency.matcher()
+                        .groupId(oldGroupId)
+                        .artifactId(oldArtifactId)
+                        .get(getCursor())
+                        .map(gmd -> gmd.map(gd -> {
+                            String declaredVersion = gd.getDeclaredVersion();
+                            if (declaredVersion != null && !declaredVersion.isEmpty()) {
+                                oldDepHadVersion = true;
+                            }
+                            return gd
+                                    .withDeclaredGroupId(newGroupId)
+                                    .withDeclaredArtifactId(newArtifactId)
+                                    .withDeclaredVersion(null)
+                                    .getTree();
+                        }))
+                        .orElse(m);
+            }
+
+            private GradleProject updateGradleModel(GradleProject gp) {
+                Map<String, GradleDependencyConfiguration> nameToConfiguration = gp.getNameToConfiguration();
+                Map<String, GradleDependencyConfiguration> newNameToConfiguration = new HashMap<>(nameToConfiguration.size());
+                boolean anyChanged = false;
+                for (GradleDependencyConfiguration gdc : nameToConfiguration.values()) {
+                    GradleDependencyConfiguration newGdc = gdc;
+                    newGdc = newGdc.withRequested(ListUtils.map(gdc.getRequested(), requested -> {
+                        if (depMatcher.matches(requested.getGroupId(), requested.getArtifactId())) {
+                            return requested.withGav(requested.getGav()
+                                    .withGroupId(newGroupId)
+                                    .withArtifactId(newArtifactId)
+                                    .withVersion(null));
+                        }
+                        return requested;
+                    }));
+                    newGdc = newGdc.withDirectResolved(ListUtils.map(gdc.getDirectResolvedShallow(), resolved -> {
+                        if (depMatcher.matches(resolved.getGroupId(), resolved.getArtifactId())) {
+                            return resolved.withGav(resolved.getGav()
+                                    .withGroupId(newGroupId)
+                                    .withArtifactId(newArtifactId));
+                        }
+                        return resolved;
+                    }));
+                    anyChanged |= newGdc != gdc;
+                    newNameToConfiguration.put(newGdc.getName(), newGdc);
+                }
+                if (anyChanged) {
+                    gp = gp.withNameToConfiguration(newNameToConfiguration);
+                }
+                return gp;
+            }
+        };
+    }
+}

--- a/recipes/src/main/java/io/quarkus/updates/core/quarkus338/ChangeTypeWithInnerClass.java
+++ b/recipes/src/main/java/io/quarkus/updates/core/quarkus338/ChangeTypeWithInnerClass.java
@@ -1,0 +1,189 @@
+package io.quarkus.updates.core.quarkus338;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AddImport;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JLeftPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+/**
+ * Wraps {@link ChangeType} but also adds the outer class import when the
+ * target is an inner class. Works around a known OpenRewrite bug where
+ * {@code ChangeType} with {@code $} inner-class notation does not add
+ * the import for the enclosing class.
+ */
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChangeTypeWithInnerClass extends Recipe {
+
+    @Option(displayName = "Old fully-qualified type name",
+            description = "Fully-qualified name of the type to replace, using $ for inner classes.")
+    String oldFullyQualifiedTypeName;
+
+    @Option(displayName = "New fully-qualified type name",
+            description = "Fully-qualified name of the replacement type, using $ for inner classes.")
+    String newFullyQualifiedTypeName;
+
+    @Override
+    public String getDisplayName() {
+        return "Change type (with inner class import fix)";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Changes a type reference and ensures the outer class import is added when the target is an inner class.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        String outerClass = getOuterClass(newFullyQualifiedTypeName);
+        if (outerClass != null) {
+            List<Recipe> recipes = new ArrayList<>();
+            recipes.add(new ChangeType(oldFullyQualifiedTypeName, newFullyQualifiedTypeName, null));
+            recipes.add(new AddImportRecipe(outerClass));
+            recipes.add(new RemoveInnerImportRecipe(newFullyQualifiedTypeName, outerClass));
+            return recipes;
+        }
+        return List.of(new ChangeType(oldFullyQualifiedTypeName, newFullyQualifiedTypeName, null));
+    }
+
+    private static String getOuterClass(String fqn) {
+        int dollarIndex = fqn.indexOf('$');
+        if (dollarIndex < 0) {
+            return null;
+        }
+        return fqn.substring(0, dollarIndex);
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    private static class RemoveInnerImportRecipe extends Recipe {
+        String innerTypeFqn;
+        String outerTypeFqn;
+
+        @Override
+        public String getDisplayName() {
+            return "Remove inner class import for " + innerTypeFqn;
+        }
+
+        @Override
+        public String getDescription() {
+            return "Removes direct inner class import and qualifies type references with the outer class name.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            String dotNotation = innerTypeFqn.replace('$', '.');
+            int lastDot = outerTypeFqn.lastIndexOf('.');
+            String qualifiedName = dotNotation.substring(lastDot + 1);
+            String innerSimpleName = dotNotation.substring(dotNotation.lastIndexOf('.') + 1);
+
+            return new JavaVisitor<>() {
+                boolean needsQualification = false;
+
+                @Override
+                public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                    needsQualification = false;
+                    for (J.Import imp : cu.getImports()) {
+                        if (imp.getTypeName().equals(innerTypeFqn)) {
+                            needsQualification = true;
+                            break;
+                        }
+                    }
+                    if (!needsQualification) {
+                        return cu;
+                    }
+                    J.CompilationUnit result = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
+                    List<J.Import> filtered = new ArrayList<>();
+                    for (J.Import imp : result.getImports()) {
+                        String typeName = imp.getTypeName();
+                        if (!typeName.equals(innerTypeFqn) && !typeName.equals(dotNotation)) {
+                            filtered.add(imp);
+                        }
+                    }
+                    return result.withImports(filtered);
+                }
+
+                @Override
+                public J visitImport(J.Import import_, ExecutionContext ctx) {
+                    return import_;
+                }
+
+                @Override
+                public J visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
+                    if (needsQualification && identifier.getSimpleName().equals(innerSimpleName)) {
+                        return buildQualifiedAccess(qualifiedName, identifier.getPrefix(), identifier.getType());
+                    }
+                    return identifier;
+                }
+
+                private Expression buildQualifiedAccess(String name, Space prefix, JavaType type) {
+                    String[] parts = name.split("\\.");
+                    Expression result = new J.Identifier(
+                            Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+                            List.of(), parts[0], null, null);
+                    for (int i = 1; i < parts.length; i++) {
+                        JavaType partType = (i == parts.length - 1) ? type : null;
+                        J.Identifier partId = new J.Identifier(
+                                Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+                                List.of(), parts[i], partType, null);
+                        result = new J.FieldAccess(
+                                Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+                                result,
+                                new JLeftPadded<>(Space.EMPTY, partId, Markers.EMPTY),
+                                partType);
+                    }
+                    return result.withPrefix(prefix);
+                }
+            };
+        }
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    private static class AddImportRecipe extends Recipe {
+        String type;
+
+        @Override
+        public String getDisplayName() {
+            return "Add import for " + type;
+        }
+
+        @Override
+        public String getDescription() {
+            return "Adds import for " + type + " if referenced.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            String simpleOuterName = type.substring(type.lastIndexOf('.') + 1);
+            return new JavaIsoVisitor<>() {
+                @Override
+                public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                    String source = cu.printAll();
+                    if (source.contains(simpleOuterName + ".")) {
+                        AddImport<ExecutionContext> addImport = new AddImport<>(type, null, false);
+                        return (J.CompilationUnit) addImport.visit(cu, ctx);
+                    }
+                    return cu;
+                }
+            };
+        }
+    }
+}

--- a/recipes/src/main/resources/quarkus-updates/core/3.38.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.38.alpha1.yaml
@@ -49,3 +49,78 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.elasticsearch.client.WarningsHandler
       newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.WarningsHandler
+
+#####
+# Quarkus Data Hibernate: rename from io.quarkus.hibernate.panache to io.quarkus.data.hibernate
+#####
+#####
+# Inner type renames must come before their outer class renames, otherwise
+# the outer rename changes the prefix and inner rules no longer match.
+# ChangeTypeWithInnerClass wraps ChangeType and adds the outer class import
+# (workaround for a known OpenRewrite bug with inner class targets).
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus338.QuarkusDataHibernateRenames
+displayName: Rename Quarkus Hibernate Panache types to Quarkus Data Hibernate
+description: >-
+  Migrate from `io.quarkus.hibernate.panache` to `io.quarkus.data.hibernate` package
+  and rename Panache types to Quarkus Data types.
+recipeList:
+  # PanacheEntity inner types (before outer class rename)
+  - io.quarkus.updates.core.quarkus338.ChangeTypeWithInnerClass:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheEntity$Reactive$Stateless
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.RecordEntity$Reactive$CustomId
+  - io.quarkus.updates.core.quarkus338.ChangeTypeWithInnerClass:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheEntity$Reactive
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.ManagedEntity$Reactive$CustomId
+  - io.quarkus.updates.core.quarkus338.ChangeTypeWithInnerClass:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheEntity$Stateless
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.RecordEntity$CustomId
+  - io.quarkus.updates.core.quarkus338.ChangeTypeWithInnerClass:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheEntity$Managed
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.ManagedEntity$CustomId
+  # PanacheRepository inner types (before outer class rename)
+  - io.quarkus.updates.core.quarkus338.ChangeTypeWithInnerClass:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheRepository$Reactive$Stateless
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.RecordRepository$Reactive$CustomId
+  - io.quarkus.updates.core.quarkus338.ChangeTypeWithInnerClass:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheRepository$Reactive
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.ManagedRepository$Reactive$CustomId
+  - io.quarkus.updates.core.quarkus338.ChangeTypeWithInnerClass:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheRepository$Stateless
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.RecordRepository$CustomId
+  - io.quarkus.updates.core.quarkus338.ChangeTypeWithInnerClass:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheRepository$Managed
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.ManagedRepository$CustomId
+  # Outer class renames
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheEntity
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.ManagedEntity
+  - io.quarkus.updates.core.quarkus338.ChangeTypeWithInnerClass:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheEntityBase
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.ManagedEntity$CustomId
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheRepository
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.ManagedRepository
+  # Standalone type renames
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.Panache
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.QuarkusData
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheQuery
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.DataQuery
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheEntityMarker
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.EntitySwitcher
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheRepositoryQueries
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.RepositoryQueries
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: io.quarkus.hibernate.panache.PanacheRepositorySwitcher
+      newFullyQualifiedTypeName: io.quarkus.data.hibernate.RepositorySwitcher
+  # Catch-all package rename for remaining types (same class name, different package)
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: io.quarkus.hibernate.panache
+      newPackageName: io.quarkus.data.hibernate
+      recursive: true

--- a/recipes/src/main/resources/quarkus-updates/core/3.38.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.38.alpha1.yaml
@@ -62,6 +62,11 @@ recipeList:
       newGroupId: io.quarkus
       newArtifactId: quarkus-data-processor
       removeVersionIfManaged: true
+  - io.quarkus.updates.core.quarkus338.ChangeGradleAnnotationProcessorDependency:
+      oldGroupId: org.hibernate.orm
+      oldArtifactId: hibernate-processor
+      newGroupId: io.quarkus
+      newArtifactId: quarkus-data-processor
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus338.ReplaceNewJpaModelgenAnnotationProcessor
@@ -72,6 +77,11 @@ recipeList:
       newGroupId: io.quarkus
       newArtifactId: quarkus-data-processor
       removeVersionIfManaged: true
+  - io.quarkus.updates.core.quarkus338.ChangeGradleAnnotationProcessorDependency:
+      oldGroupId: org.hibernate.orm
+      oldArtifactId: hibernate-jpamodelgen
+      newGroupId: io.quarkus
+      newArtifactId: quarkus-data-processor
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.quarkus.updates.core.quarkus338.ReplaceOldJpaModelgenAnnotationProcessor
@@ -82,6 +92,11 @@ recipeList:
       newGroupId: io.quarkus
       newArtifactId: quarkus-data-processor
       removeVersionIfManaged: true
+  - io.quarkus.updates.core.quarkus338.ChangeGradleAnnotationProcessorDependency:
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jpamodelgen
+      newGroupId: io.quarkus
+      newArtifactId: quarkus-data-processor
 
 #####
 # Quarkus Data Hibernate: rename from io.quarkus.hibernate.panache to io.quarkus.data.hibernate

--- a/recipes/src/main/resources/quarkus-updates/core/3.38.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.38.alpha1.yaml
@@ -49,6 +49,39 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.elasticsearch.client.WarningsHandler
       newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.WarningsHandler
+#####
+# Replace hibernate-processor annotation processor with quarkus-data-processor
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus338.ReplaceHibernateProcessorAnnotationProcessor
+recipeList:
+  - io.quarkus.updates.core.quarkus37.ChangeMavenCompilerAnnotationProcessorGroupIdAndArtifactId:
+      oldGroupId: org.hibernate.orm
+      oldArtifactId: hibernate-processor
+      newGroupId: io.quarkus
+      newArtifactId: quarkus-data-processor
+      removeVersionIfManaged: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus338.ReplaceNewJpaModelgenAnnotationProcessor
+recipeList:
+  - io.quarkus.updates.core.quarkus37.ChangeMavenCompilerAnnotationProcessorGroupIdAndArtifactId:
+      oldGroupId: org.hibernate.orm
+      oldArtifactId: hibernate-jpamodelgen
+      newGroupId: io.quarkus
+      newArtifactId: quarkus-data-processor
+      removeVersionIfManaged: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus338.ReplaceOldJpaModelgenAnnotationProcessor
+recipeList:
+  - io.quarkus.updates.core.quarkus37.ChangeMavenCompilerAnnotationProcessorGroupIdAndArtifactId:
+      oldGroupId: org.hibernate
+      oldArtifactId: hibernate-jpamodelgen
+      newGroupId: io.quarkus
+      newArtifactId: quarkus-data-processor
+      removeVersionIfManaged: true
 
 #####
 # Quarkus Data Hibernate: rename from io.quarkus.hibernate.panache to io.quarkus.data.hibernate


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/pull/54610 for the rename details.

This required a custom rewrite rule because openrewrite otherwise kept importing the inner types directly, leading to something that was absolutely against the API style.