### PR TITLE
Add a simple migration recipe for Elasticsearch low-level client migration

### DIFF
--- a/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate338Test.java
+++ b/recipes-tests/src/test/java/io/quarkus/updates/core/CoreUpdate338Test.java
@@ -1,0 +1,218 @@
+package io.quarkus.updates.core;
+
+import static org.openrewrite.java.Assertions.java;
+
+import java.nio.file.Path;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CoreUpdate338Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        @Language("java")
+        String restClient = """
+                package org.elasticsearch.client;
+
+                import java.io.Closeable;
+
+                public class RestClient implements Closeable {
+                    public static RestClientBuilder builder(Object... hosts) {
+                        return null;
+                    }
+                    public Response performRequest(Request request) { return null; }
+                    public void close() {}
+
+                    public static class FailureListener {}
+                }
+                """;
+        @Language("java")
+        String restClientBuilder = """
+                package org.elasticsearch.client;
+
+                public class RestClientBuilder {
+                    public RestClient build() { return null; }
+                    public interface HttpClientConfigCallback {}
+                }
+                """;
+        @Language("java")
+        String request = """
+                package org.elasticsearch.client;
+
+                public class Request {
+                    public Request(String method, String endpoint) {}
+                    public void setJsonEntity(String entity) {}
+                }
+                """;
+        @Language("java")
+        String response = """
+                package org.elasticsearch.client;
+
+                public class Response {
+                    public Object getEntity() { return null; }
+                }
+                """;
+        @Language("java")
+        String responseException = """
+                package org.elasticsearch.client;
+
+                public class ResponseException extends java.io.IOException {
+                    public Response getResponse() { return null; }
+                }
+                """;
+        @Language("java")
+        String responseListener = """
+                package org.elasticsearch.client;
+
+                public interface ResponseListener {
+                    void onSuccess(Response response);
+                    void onFailure(Exception exception);
+                }
+                """;
+        @Language("java")
+        String requestOptions = """
+                package org.elasticsearch.client;
+
+                public class RequestOptions {
+                    public static final RequestOptions DEFAULT = null;
+                    public static class Builder {}
+                }
+                """;
+        @Language("java")
+        String cancellable = """
+                package org.elasticsearch.client;
+
+                public interface Cancellable {
+                    void cancel();
+                }
+                """;
+        CoreTestUtil.recipe(spec, Path.of("quarkus-updates", "core", "3.38.alpha1.yaml"))
+                .parser(JavaParser.fromJavaVersion()
+                        .dependsOn(restClient, restClientBuilder, request, response,
+                                responseException, responseListener, requestOptions,
+                                cancellable)
+                        .logCompilationWarningsAndErrors(true))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void testRestClientToRest5Client() {
+        //language=java
+        rewriteRun(java(
+                """
+                package org.acme;
+
+                import org.elasticsearch.client.RestClient;
+
+                public class ElasticsearchService {
+                    private RestClient client;
+
+                    public void setClient(RestClient client) {
+                        this.client = client;
+                    }
+                }
+                """,
+                """
+                package org.acme;
+
+                import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+
+                public class ElasticsearchService {
+                    private Rest5Client client;
+
+                    public void setClient(Rest5Client client) {
+                        this.client = client;
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testRestClientBuilderToRest5ClientBuilder() {
+        //language=java
+        rewriteRun(java(
+                """
+                package org.acme;
+
+                import org.elasticsearch.client.RestClientBuilder;
+
+                public class ClientFactory {
+                    private RestClientBuilder builder;
+                }
+                """,
+                """
+                package org.acme;
+
+                import co.elastic.clients.transport.rest5_client.low_level.Rest5ClientBuilder;
+
+                public class ClientFactory {
+                    private Rest5ClientBuilder builder;
+                }
+                """));
+    }
+
+    @Test
+    void testRequestAndResponseMigration() {
+        //language=java
+        rewriteRun(java(
+                """
+                package org.acme;
+
+                import org.elasticsearch.client.Request;
+                import org.elasticsearch.client.Response;
+                import org.elasticsearch.client.RestClient;
+
+                public class SearchService {
+                    private RestClient client;
+
+                    public Response search() throws Exception {
+                        Request request = new Request("GET", "/index/_search");
+                        return client.performRequest(request);
+                    }
+                }
+                """,
+                """
+                package org.acme;
+
+                import co.elastic.clients.transport.rest5_client.low_level.Request;
+                import co.elastic.clients.transport.rest5_client.low_level.Response;
+                import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+
+                public class SearchService {
+                    private Rest5Client client;
+
+                    public Response search() throws Exception {
+                        Request request = new Request("GET", "/index/_search");
+                        return client.performRequest(request);
+                    }
+                }
+                """));
+    }
+
+    @Test
+    void testHttpClientConfigCallbackMigration() {
+        //language=java
+        rewriteRun(java(
+                """
+                package org.acme;
+
+                import org.elasticsearch.client.RestClientBuilder;
+
+                public class MyConfigurator implements RestClientBuilder.HttpClientConfigCallback {
+                }
+                """,
+                """
+                package org.acme;
+
+                import io.quarkus.elasticsearch.restclient.lowlevel.ElasticsearchClientConfigConfigurer;
+
+                public class MyConfigurator implements ElasticsearchClientConfigConfigurer {
+                }
+                """));
+    }
+}

--- a/recipes/src/main/resources/quarkus-updates/core/3.38.alpha1.yaml
+++ b/recipes/src/main/resources/quarkus-updates/core/3.38.alpha1.yaml
@@ -1,0 +1,51 @@
+#####
+# Elasticsearch REST client migration
+# Migrate from org.elasticsearch.client (REST 4) to co.elastic.clients.transport.rest5_client.low_level (REST 5)
+# See https://github.com/quarkusio/quarkus/commit/a6b51c11611551beb0a5ebbbbef0b097c6be0369
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.quarkus.updates.core.quarkus338.ElasticsearchRestClientMigration
+description: Migrate Elasticsearch low-level REST client from org.elasticsearch.client to co.elastic.clients.transport.rest5_client.low_level.
+recipeList:
+  # Configurer changed and the user needs to rewrite the method, we only change the type
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
+      newFullyQualifiedTypeName: io.quarkus.elasticsearch.restclient.lowlevel.ElasticsearchClientConfigConfigurer
+  # Main client classes
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.RestClient
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.Rest5Client
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.RestClientBuilder
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.Rest5ClientBuilder
+  # Request/Response
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.Request
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.Request
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.Response
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.Response
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.ResponseException
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.ResponseException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.ResponseListener
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.ResponseListener
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.RequestOptions
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.RequestOptions
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.Cancellable
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.Cancellable
+  # Async response handling
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.HttpAsyncResponseConsumerFactory
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.HttpAsyncResponseConsumerFactory
+  # Warnings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.WarningFailureException
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.WarningFailureException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.elasticsearch.client.WarningsHandler
+      newFullyQualifiedTypeName: co.elastic.clients.transport.rest5_client.low_level.WarningsHandler


### PR DESCRIPTION
`org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback` also changes the method signature ... but I guess we don't want to make these rules too complex ?
Other than that, it should change the client + request/response types