### PR TITLE
Set `recursive` on the camel-test junit5 to junit6 package rename

### DIFF
--- a/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3.31.yaml
+++ b/recipes/src/main/resources/quarkus-updates/org.apache.camel.quarkus/camel-quarkus/3.31.yaml
@@ -33,6 +33,7 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.camel.test.junit5
       newPackageName: org.apache.camel.test.junit6
+      recursive: true
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.apache.camel.quarkus
       oldArtifactId: camel-quarkus-junit5


### PR DESCRIPTION
`org.apache.camel.test.junit5` → `org.apache.camel.test.junit6` omits `recursive`, so the two subpackages are never renamed:

| old (camel-test-junit5 4.8.1) | new (camel-test-junit6 4.21.0) |
| --- | --- |
| `org.apache.camel.test.junit5.params` | `org.apache.camel.test.junit6.params` |
| `org.apache.camel.test.junit5.util` | `org.apache.camel.test.junit6.util` |

Both exist under prefix substitution, so recursion is safe and required here.

Context: openrewrite/rewrite#8382 pins `ChangePackage.recursive` to mean non-recursive when unset, which makes this dependency explicit. Correct either way.